### PR TITLE
Corrected typing and formatting errors

### DIFF
--- a/easyodds.pl
+++ b/easyodds.pl
@@ -28,11 +28,11 @@ render
 	
 	html(
 		[ div(class(card), div(class('card-body'),
-		    [ h1(class('card-title'), "Clinical Study"),
+		    [ h1(class('card-title'), "Odds ratio"),
 		      p(class('card-text'),
-		       [ "The Odds for sucess with treatment A are ", 
-			 \mmlm([r(Odds_A), ","]), " treatment B has a probability of success of ",
-			 \mmlm([r(Pi_B), ","]), " and the Odds Ratio between both treatments is ",
+		       [ "The odds for succeding with treatment A are ", 
+			 \mmlm([r(Odds_A), ","]), " while treatment B has a success probability of ",
+			 \mmlm([r(Pi_B), "."]), " The odds ratio between both treatments is ",
 		         \mmlm([r(OR), "."])
 		       ])]))]).
 
@@ -40,7 +40,7 @@ task(oratio)
 --> { start(item(_Odds_A, _Pi_B, _OR)),
       session_data(resp(easyodds, oratio, Resp), resp(easyodds, oratio, '#.##'))
 	}, 
-	html(\htmlform(["What is the probability of sucess with treatment A?"], oratio, Resp)).
+	html(\htmlform(["What is the success probability for treatment A?"], oratio, Resp)).
 
 % Odds ratio with two probabilities. 
 intermediate(oratio, item).
@@ -48,16 +48,15 @@ start(item(odds_A, pi_B, or)).
 
 expert(oratio, stage(2), From, To, [step(expert, odd, [])]) :-
     From = item(Odds_A, _Pi_B, _OR),
-    To = { '<-'(pi_A, dfrac(Odds_A, 1 + Odds_A)) ;
-	   pi_A
+    To = { '<-'(pi_A, dfrac(Odds_A, 1 + Odds_A))
 	 }.
 
-feedback(odd, [], Col, FB) =>
-    FB = [ "Correctly recognised the problem as an ", 
-           \mmlm(Col, hyph(odds, "ratio")), "."].
+feedback(odd, [], _Col, FB) =>
+    FB = [ "Correctly calculated the success probability from ", \mmlm([odds_A, "."]) ].
+           
 
-hint(odd, [], Col, FB) =>
-    FB = [ "This is an ", \mmlm(Col, hyph(odds, "ratio")), "."].
+hint(odd, [], _Col, FB) =>
+    FB = [ "This is an odds ratio."].
 
 % 1) Tried conversion from odds to odds, as if starting with 
 %    a probability.
@@ -66,11 +65,11 @@ buggy(oratio, stage(2), From, To, [step(buggy, sub, [Odds_A])]) :-
     To = instead(sub, 1 - Odds_A, 1 + Odds_A).
 
 feedback(sub, [Odds_A], Col, FB) =>
-    FB = [ "Please use the formula converting, ", \mmlm(Col, color(sub, Odds_A)), " to ", 
-	   \mmlm(Col, color(sub, pi_A)) ].
+    FB = [ "Please use the correct formula to convert ", \mmlm(Col, color(sub, Odds_A)), " to ", 
+	   \mmlm(Col, [color(sub, pi_A), "."]) ].
 
-hint(sub, [Odds_A], Col, FB) =>
-    FB = [ "Do not try to further convert ", \mmlm(Col, color(sub, Odds_A)), " to odds." ].
+hint(sub, [_Odds_A], _Col, FB) =>
+    FB = [ "Do not apply the formula to calculate the odds from the success probability." ].
 
 % 2) Used pi_B rather than odds_A.
 buggy(oratio, stage(1), From, To, [step(buggy, pi, [])]) :-
@@ -78,19 +77,19 @@ buggy(oratio, stage(1), From, To, [step(buggy, pi, [])]) :-
     To = instead(pi, pi_B, odds_A).
 
 feedback(pi, [], Col, FB) =>
-    FB = [ "Please extract and use the value for ", \mmlm(Col, color(pi, odds_A)), " instead." ].
+    FB = [ "Please use ", \mmlm(Col, color(pi, odds_A)), " instead of ", \mmlm(Col, [color(pi, pi_B), "."]) ].
 
 hint(pi, [], Col, FB) =>
-    FB = [ "Do not execute your calculations using ", \mmlm(Col, color(pi,  pi_B)) ].
+    FB = [ "Do not use the success probability for therapy B ", \mmlm(Col, [color(pi,  pi_B), "."]) ].
 
-% 3) Used or rather than odds_A.
+% 3) Used OR rather than odds_A.
 buggy(oratio, stage(1), From, To, [step(buggy, ratio, [])]) :-
     From = odds_A,
     To = instead(ratio, or, odds_A).
 
 feedback(ratio, [], Col, FB) =>
-    FB = [ "Please extract and use the value for ", \mmlm(Col, color(ratio, odds_A)), " instead." ].
+    FB = [ "Please use ", \mmlm(Col, color(ratio, odds_A)), " instead of ", \mmlm(Col, [color(ratio, or), "."]) ].
 
 hint(ratio, [], Col, FB) =>
-    FB = [ "Do not execute your calculations using the ", \mmlm(Col, color(ratio,  "OR")) ].
+    FB = [ "Do not use the odds ratio ", \mmlm(Col, [color(ratio, or), "."]) ].
 

--- a/oddsratio.pl
+++ b/oddsratio.pl
@@ -35,16 +35,16 @@ render
           div(class('card-body'),
             [ h1(class('card-title'), "Odds ratio"),
 		      p(class('card-text'),
-                [ "We consider two therapies A and B. The success probability of Therapy A ",
+                [ "We consider two therapies A and B. The success probability of therapy A ",
                   "is ", \mmlm([r(Pi_A), "."]), " The odds ratio is ", \mmlm(r(OR)), "relative ",
-                  "to Therapy A."
+                  "to therapy A."
                 ])]))]).
 
 task(oratio)
 --> { start(item(_Pi_A, _OR)),
       session_data(resp(oddsratio, oratio, Resp), resp(oddsratio, oratio, '#.##'))
 	},
-	html(\htmlform(["What is the success probability of Therapy B?"], oratio, Resp)).
+	html(\htmlform(["What is the success probability of therapy B?"], oratio, Resp)).
       
 
 intermediate(oratio, item).
@@ -72,12 +72,13 @@ expert(oratio, stage(1), From, To, [step(expert, odds, [Pi_A, odds_A])]) :-
 
 feedback(odds, [Pi_A, _], Col, FB)
  => FB = [ "Correctly determined the odds ",
-           "from ", \mmlm(Col, Pi_A)
+           "from ", \mmlm(Col, [Pi_A, "."])
          ].
 
 hint(odds, [Pi_A, Odds_A], Col, FB)
- => FB = [ "Convert ", \mmlm(Col, Pi_A), " to the respective ",
-           "odds, ", \mmlm(Col, Odds_A = dfrac(Pi_A, 1 - Pi_A))
+ => FB = [ "Convert the success probability of therapy A, ", 
+            \mmlm(Col, [Pi_A, ","]), " to the respective ",
+            "odds, ", \mmlm(Col, [Odds_A = dfrac(Pi_A, 1 - Pi_A), "."])
          ].
 
 % Calculate the odds for B
@@ -88,12 +89,12 @@ expert(oratio, stage(2), From, To, [step(expert, odds_ratio, [Odds_A, odds_B])])
 
 feedback(odds_ratio, [_Odds_A, Odds_B], Col, FB)
  => FB = [ "Sucessfully ",
-           "calculated ", \mmlm(Col, Odds_B)
+           "calculated ", \mmlm(Col, [Odds_B, "."])
          ].
 
 hint(odds_ratio, [Odds_A, Odds_B], Col, FB)
  => FB = [ "Multiply ", \mmlm(Col, Odds_A), " by the odds ratio to ",
-           "obtain ", \mmlm(Col, Odds_B)
+           "obtain ", \mmlm(Col, [Odds_B, "."])
          ].
 
 % Determine the probability for B
@@ -103,13 +104,15 @@ expert(oratio, stage(3), From, To, [step(expert, inv_odds, [Odds_B, pi_B])]) :-
     To = dfrac(Odds_B, 1 + Odds_B).
 
 feedback(inv_odds, [Odds_B, _], Col, FB)
- => FB = ["Correctly determined the success probability from ", \mmlm(Col, Odds_B)].
+ => FB = ["Correctly determined the success probability from ", \mmlm(Col, [Odds_B, "."])].
 
 hint(inv_odds, [Odds_B, Pi_B], Col, FB)
  => FB = [ "Back-transform ", \mmlm(Col, Odds_B), " to the respective success ",
-           "probability, ", \mmlm(Col, Pi_B = dfrac(Odds_B, 1 + Odds_B))
+           "probability, ", \mmlm(Col, [Pi_B = dfrac(Odds_B, 1 + Odds_B), "."])
          ].
 
+
+%%Buggy rules
 % Forgot conversion of pi_A to odds_A
 buggy(oratio, stage(1), From, To, [step(buggy, forget_odds, [Pi_A, odds_A])]) :-
     From = odds(Pi_A),
@@ -118,7 +121,7 @@ buggy(oratio, stage(1), From, To, [step(buggy, forget_odds, [Pi_A, odds_A])]) :-
 feedback(forget_odds, [Pi_A, Odds_A], Col, FB)
  => FB = [ "Please remember to ",
            "convert ", \mmlm(Col, color(forget_odds, Pi_A)), " ",
-           "to ", \mmlm(Col, color(forget_odds, Odds_A = frac(Pi_A, 1 - Pi_A)))
+           "to ", \mmlm(Col, [color(forget_odds, Odds_A = frac(Pi_A, 1 - Pi_A)), "."])
          ].
 
 hint(forget_odds, [Pi_A, _Odds_A], Col, FB)
@@ -127,7 +130,7 @@ hint(forget_odds, [Pi_A, _Odds_A], Col, FB)
            "respective odds."
          ].
 
-% Divided odds_A and or rather then multiplying them.
+% Divided odds_A and OR rather then multiplying them.
 buggy(oratio, stage(2), From, To, [step(buggy, divide, [Odds_A, OR])]) :-
     From = odds_ratio(Odds_A, OR),
     To = instead(divide, Odds_A / OR, Odds_A * OR).
@@ -151,7 +154,7 @@ buggy(oratio, stage(3), From, To, [step(buggy, forget_prob, [Odds_B, pi_B])]) :-
 feedback(forget_prob, [Odds_B, Pi_B], Col, FB)
  => FB = [ "Please remember to ",
            "back-transform ", \mmlm(Col, color(forget_prob, Odds_B)), " to ",
-           \mmlm(Col, color(forget_prob, Pi_B = frac(Odds_B, 1 + Odds_B)))
+           \mmlm(Col, [color(forget_prob, Pi_B = frac(Odds_B, 1 + Odds_B)), "."])
          ].
 
 hint(forget_prob, [Odds_B, _Pi_B], Col, FB)
@@ -159,3 +162,22 @@ hint(forget_prob, [Odds_B, _Pi_B], Col, FB)
            "back-transform ", \mmlm(Col, color(forget_prob, Odds_B)), " to ",
            "the respective probability."
          ].
+
+% Used OR instead of Pi_A: Needs to be fixed, because causes stack overflow
+/* buggy(oratio, stage(1), From, To, [step(buggy, wrong_pi_A, [Pi_A, OR])]) :-
+    From = odds(Pi_A),
+    To = instead(wrong_pi_A, Pi_A, OR).
+
+feedback(wrong_pi_A, [Pi_A, OR, Odds_A], Col, FB)
+ => FB = [ "Please use the success probability ",
+           \mmlm(Col, color(wrong_pi_A, Pi_A)), " to calculate the respective ",
+          \mmlm(Col, color(wrong_pi_A, Odds_A)), " instead of the odds ratio ",
+           \mmlm(Col, [color(wrong_pi_A, OR), "."])
+         ].
+
+hint(wrong_pi_A, [Pi_A, OR, Odds_A], Col, FB)
+ => FB = [ "Don't use the odds ratio ", \mmlm(Col, color(wrong_pi_A, OR)),
+           "to calculate ", \mmlm(Col, [color(wrong_pi_A, Odds_A), "."]),
+           " Use the the success probability ", \mmlm(Col, color(wrong_pi_A, Pi_A)),
+           " instead."
+         ].  */

--- a/oddsratio2.pl
+++ b/oddsratio2.pl
@@ -35,7 +35,7 @@ render
           div(class('card-body'),
             [ h1(class('card-title'), "Odds ratio"),
               p(class('card-text'),
-                [ "The success probability of Therapy A ",
+                [ "The success probability of therapy A ",
                   "is ", \mmlm([r(Pi_A), "."]), " Therapy B has a success ",
                   "probability of ", \mmlm([r(Pi_B), "."])
                 ])]))]).
@@ -44,7 +44,7 @@ task(oratio)
 --> { start(item(_Pi_A, _Pi_B)),
       session_data(resp(oddsratio2, oratio, Resp), resp(oddsratio2, oratio, '#.##'))
 	}, 
-    html(\htmlform(["What is the odds ratio relative to Therapy A?"], oratio, Resp)).
+    html(\htmlform(["What is the odds ratio relative to therapy A?"], oratio, Resp)).
 
 
 % Odds ratio with two probabilities
@@ -72,11 +72,11 @@ expert(oratio, stage(1), From, To, [step(expert, odds, [Pi, Odds])]) :-
     To = '<-'(Odds, dfrac(Pi, 1 - Pi)).
 
 feedback(odds, [Pi, _], Col, FB)
- => FB = [ "Correctly determined the odds ", "from ", \mmlm(Col, Pi) ].
+ => FB = [ "Correctly determined the odds ", "from ", \mmlm(Col, [Pi, "."]) ].
 
 hint(odds, [Pi, Odds], Col, FB)
  => FB = [ "Convert ", \mmlm(Col, Pi), " to the respective ",
-           "odds, ", \mmlm(Col, Odds = dfrac(Pi, 1 - Pi))
+           "odds, ", \mmlm(Col, [Odds = dfrac(Pi, 1 - Pi), "."])
          ].
 
 % Calculate OR
@@ -86,7 +86,7 @@ expert(oratio, stage(2), From, To, [step(expert, odds_ratio, [Odds_B, Odds_A])])
     To = Odds_B / Odds_A.
 
 feedback(odds_ratio, [Odds_B, Odds_A], Col, FB)
- => FB = [ "Sucessfully calculated ", \mmlm(Col, Odds_B / Odds_A) ].
+ => FB = [ "Sucessfully calculated ", \mmlm(Col, [Odds_B / Odds_A, "."]) ].
 
 hint(odds_ratio, [Odds_B, Odds_A], Col, FB)
  => FB = [ "Divide ", \mmlm(Col, Odds_B), " by ", \mmlm(Col, Odds_A), " to ",
@@ -101,7 +101,7 @@ buggy(oratio, stage(1), From, To, [step(buggy, forget_odds, [Pi, Odds])]) :-
 feedback(forget_odds, [Pi, Odds], Col, FB)
  => FB = [ "Please remember to ",
            "convert ", \mmlm(Col, color(forget_odds, Pi)), " ",
-           "to ", \mmlm(Col, color(forget_odds, Odds = frac(Pi, 1 - Pi)))
+           "to ", \mmlm(Col, [color(forget_odds, Odds = frac(Pi, 1 - Pi)), "."])
          ].
 
 hint(forget_odds, [Pi, _Odds], Col, FB)
@@ -119,7 +119,7 @@ feedback(inverse, [Odds_B, Odds_A], Col, FB)
  => FB = [ "The result matches the inverse, ",
            "with ", \mmlm(Col, color(inverse, Odds_A)), " being divided ",
            "by ", \mmlm(Col, color(inverse, Odds_B)), " instead ",
-           "of ", \mmlm(Col, color(inverse, Odds_B / Odds_A)) 
+           "of ", \mmlm(Col, [color(inverse, Odds_B / Odds_A), "."]) 
          ].
 
 hint(inverse, [_Odds_B, _Odds_A], _Col, FB)
@@ -132,7 +132,7 @@ buggy(oratio, stage(2), From, To, [step(buggy, product, [Odds_B, Odds_A])]) :-
 
 feedback(product, [Odds_B, Odds_A], Col, FB)
  => FB = [ "The result matches the product of the two odds instead ",
-           "of the ratio, ", \mmlm(Col, color(product, Odds_B / Odds_A))
+           "of the ratio, ", \mmlm(Col, [color(product, Odds_B / Odds_A), "."])
          ].
 
 hint(product, [_Odds_B, _Odds_A], _Col, FB)

--- a/server.pl
+++ b/server.pl
@@ -47,6 +47,7 @@ http:location(mcclass, root(mcclass), []).
 :- http_handler(mcclass(oddsratio), handler(oddsratio), []).
 :- http_handler(mcclass(oddsratio2), handler(oddsratio2), []).
 :- http_handler(mcclass(easyodds), handler(easyodds), []).
+:- http_handler(mcclass(subgroups), handler(subgroups), []).
 :- http_handler(mcclass(ztrans), handler(ztrans), []).
 :- http_handler(mcclass(ztrans2), handler(ztrans2), []).
 :- http_handler(mcclass(tgroups), handler(tgroups), []).
@@ -56,7 +57,7 @@ http:location(mcclass, root(mcclass), []).
 :- http_handler(mcclass(chisq), handler(chisq), []).
 :- http_handler(mcclass(power), handler(power), []).
 :- http_handler(mcclass(cigroups), handler(cigroups), []).
-:- http_handler(mcclass(subgroups), handler(subgroups), []).
+
 
 handler(Topic, Request) :-
     member(method(post), Request),

--- a/tgroups.pl
+++ b/tgroups.pl
@@ -55,9 +55,9 @@ render
               "mixture of online courses and classical training of motor ",
               "skill with the so-called Box-trainer (Box group). ",
               "The primary dependent variable is the result on the OSATS ",
-              "test (interval scaled, normally distributed, high scores = ",
+              "test (interval scale, normally distributed, high scores = ",
               "good performance). A few more dependent variables were ",
-              "assessed, including a knowledge test (interval scaled), ",
+              "assessed, including a knowledge test (interval scale), ",
               "operation time (dichotomized, above or below 80 min), and ",
               "efficiency ratings (ordinal scale, 1=bad ... 5=good)."
             ]),
@@ -71,7 +71,7 @@ render
                 [ "“Laparoscopy-naïve medical students were randomized into ",
                   "two groups. The Box ",
                   "group ", \mmlm(["(", N_BOX = r(n_box), ")"]), " used ",
-                  "E-learning for laparoscopic cholecystectomy and practiced ",
+                  "e-learning for laparoscopic cholecystectomy and practiced ",
                   "basic skills with Box trainers. The VR ",
                   "group ", \mmlm(["(", N_VR = r(n_vr), ")"]), " trained ",
                   "basic skills and laparoscopic cholecystectomy on ",
@@ -89,7 +89,7 @@ render
                   " vs. BOX: ", \mmlm([digits(1)], r(box)), " ± ", \mmlm([digits(1)], r(s_box)), 
                   ", p = 0.437). The significance level is set to ",
                   \mmlm(alpha = perc(r(Alpha))), " two-tailed. ",
-                  "Students generally liked training and felt well prepared for ", 
+                  "The medical students generally appreciated the training and felt well prepared for ", 
                   "assisting in laparoscopic surgery. The efficiency of the training ",
                   "was judged higher by the VR group than by the Box group."
                 ]))),
@@ -101,8 +101,8 @@ task(s2p)
       session_data(resp(tgroups2, s2p, Resp), resp(tgroups2, s2p, '#.##'))
     },
     html(\htmlform(
-      [ "Compare the OSATS-Scores of both Groups, assuming homogeneity",
-        " of variance and calculate the the pooled variance ", \mmlm(s2p), "."
+      [ "Compare the OSATS scores of both groups assuming homogeneity",
+        " of variance and calculate the pooled variance ", \mmlm([s2p, "."])
       ], s2p, Resp)).
 
 % Question for independent t-test.
@@ -112,7 +112,7 @@ task(tratio)
     },
     html(\htmlform(
       [ "Is VR training superior to traditional Box training? ",
-        "Please report the ", \mmlm(hyph(t, "ratio,")), " using Box ",
+        "Please report the ", \mmlm(hyph(t, "ratio")), " using the Box training",
         "as the control intervention." 
       ], tratio, Resp)).
 
@@ -122,7 +122,7 @@ task(cigroups)
       session_data(resp(cigroups, cigroups, Resp), resp(cigroups, cigroups, '#.# to #.#'))
     },
     html(\htmlform(["Determine the confidence interval for the difference ",
-        "between the two group means using Box as the control intervention."],
+        "between the two group means using the Box training as the control intervention."],
 	cigroups, Resp)).
 
 %
@@ -140,8 +140,7 @@ expert(s2p, stage(2), From, To, [step(expert, indep, [])]) :-
 	 }.
 
 feedback(indep, [], Col, FB) =>
-    FB = [ "Correctly determined the pooled variance ", \mmlm(Col, s2p), "."
-	 ].
+    FB = [ "Correctly determined the pooled variance ", \mmlm(Col, [s2p, "."]) ].
 
 hint(indep, [], Col, FB) =>
     FB = [ "The pooled variance ", \mmlm(Col, s2p), " needs to be ",
@@ -158,14 +157,13 @@ buggy(s2p, stage(2), From, To, [step(buggy, sd, [S_VR, S_Box])]) :-
 
 feedback(sd, [S_VR, S_Box], Col, FB) =>
     FB = [ "The result matches the expression for the pooled variance with the",
-	   " standard deviation instead of the standard variations ",
-	   \mmlm(Col, color(sd, S_VR)), " and ", \mmlm(Col, color(sd, S_Box)), ".",
-	   " Please remember to use the squares of ", \mmlm(Col, color(sd, S_VR)),
+	   " standard deviation instead of the standard variations.",
+	   " Please remember to use the squares of the standard deviations ", \mmlm(Col, color(sd, S_VR)),
 	   " and ", \mmlm(Col, color(sd, S_Box)), " to calculate the pooled variance."
 	 ].
 
 hint(sd, [_S_VR, _S_Box], _Col, FB) =>
-    FB = [ "Do not forget to use the square of the standard variations ",
+    FB = [ "Do not forget to use the square of the standard deviations ",
            "when calculating the pooled variance."
 	 ].
 
@@ -183,9 +181,7 @@ feedback(nswap, [N_VR, N_Box], Col, FB) =>
 	 ].
 
 hint(nswap, [_N_VR, _N_Box], Col, FB) =>
-    FB = [ "Do not swap the sample sizes in ", \mmlm(Col, color(nswap, s2p)),
-	   "."
-	 ].
+    FB = [ "Do not swap the sample sizes in the formula for the pooled variance ", \mmlm(Col, [color(nswap,s2p), "."]) ].
 
 %
 %% Expert Rules for independent t-test task
@@ -221,7 +217,7 @@ expert(tratio, stage(1), From, To, [step(expert, pooled, [S2P])]) :-
     To = '<-'(S2P, dfrac((N_A-1) * S_A^2 + (N_B-1) * S_B^2, N_A + N_B - 2)).
 
 feedback(pooled, [S2P], Col, FB)
- => FB = [ "Correctly determined the pooled variance ", \mmlm(Col, S2P) ].
+ => FB = [ "Correctly determined the pooled variance ", \mmlm(Col, [S2P, "."]) ].
 
 hint(pooled, [S2P], Col, FB)
  => FB = [ "The pooled variance ", \mmlm(Col, S2P), " needs to be ",
@@ -238,8 +234,8 @@ feedback(tratio, [_T], Col, FB) =>
     FB = [ "Correctly determined the ",  \mmlm(Col, hyph(t, "statistic.")) ].
 
 hint(tratio, [T], Col, FB) =>
-    FB = [ "The ", \mmlm(Col, hyph(t, "statistic")), " must be determined, ", 
-           \mmlm(Col, T) 
+    FB = [ "The ", \mmlm(Col, hyph(t, "statistic")), " must be determined: ", 
+           \mmlm(Col, [T, "."]) 
          ].
 
 %
@@ -254,7 +250,7 @@ feedback(control, [VR, Box], Col, FB)
  => FB = [ "The sign of the result matches the ",
            "negative ", \mmlm(Col, hyph(t, "ratio,")), " ",
            "with ", \mmlm(Col, color(control, VR)), " subtracted ",
-           "from ", \mmlm(Col, [color(control, Box)]), ". Please keep in mind ",
+           "from ", \mmlm(Col, [color(control, Box), "."]), " Please keep in mind ",
 	   "that the control intervention must be subtracted from the tested ",
 	   "intervention."
          ].
@@ -274,14 +270,14 @@ buggy(tratio, stage(1), From, To, [step(buggy, square, [S_A, S_B])]) :-
 feedback(square, [S_A, S_B], Col, FB)
  => FB = [ "The result matches the expression for the pooled variance without ",
 	   "the square of ", \mmlm(Col, color(square, S_A)), " and ", 
-	   \mmlm(Col, color(square, S_B)), ". Please do not forget the square of ",
+	   \mmlm(Col, [color(square, S_B), "."]), " Please do not forget the square of ",
 	   \mmlm(Col, color(square, S_A)), " and ", \mmlm(Col, color(square, S_B)),
 	   "when calculating the pooled variance."
          ].
 
 hint(square, [_S_A, _S_B], Col, FB)
  => FB = [ "Do not forget to use the square of the standard deviations ",
-           "when calculating the pooled variance ", \mmlm(Col, color(square, s2p)), "." 
+           "when calculating the pooled variance ", \mmlm(Col, color(square, [s2p, "."])) 
          ].
 
 % Buggy-Rule: Forgot school math [1/N1 + 1/N2 is not 1/(N1 + N2)]
@@ -292,16 +288,15 @@ buggy(tratio, stage(2), From, To, [step(buggy, school, [N_A, N_B])]) :-
 feedback(school, [A, B], Col, FB)
  => FB = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " for independent samples with ",
-	   \mmlm(Col, frac(1, color(school, color("black", A) + color("black", B)))),
-	   ". Please keep in mind that ", \mmlm(Col, color(school, 
+	   \mmlm(Col, [frac(1, color(school, color("black", A) + color("black", B))), "."]),
+	   " Please keep in mind that ", \mmlm(Col, [color(school, 
 		color("black", frac(1, A)) + color("black", frac(1, B)))
-		=\= frac(1, color(school, color("black", A) + color("black", B)))), "."
+		=\= frac(1, color(school, color("black", A) + color("black", B))), "."])
          ].
 
 hint(school, [A, B], Col, FB)
  => FB = [ "Do not forget that ",
-           \mmlm(Col, color(school, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school, color("black", A) + color("black", B)))), 
-           "."
+           \mmlm(Col, [color(school, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school, color("black", A) + color("black", B))), "."])
          ].
 
 %% Buggy-Rule: Forgot paranthesis around numerator in t-statistic.
@@ -332,8 +327,8 @@ buggy(tratio, stage(2), From, To, [step(buggy, sqrt1, [S2P * Ns])]) :-
 
 feedback(sqrt1, [S2P_Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 
-	   \mmlm(Col, hyph(t, "ratio")), "for independent samples without the square",
-	   " root around ", \mmlm(Col, color(sqrt1, S2P_Ns)), ". Please do not forget",
+	   \mmlm(Col, hyph(t, "ratio")), " for independent samples without the square",
+	   " root around ", \mmlm(Col, [color(sqrt1, S2P_Ns), "."]), " Please do not forget",
 	   " the square root around the denominator."
          ].
 
@@ -351,7 +346,7 @@ buggy(tratio, stage(2), From, To, [step(buggy, sqrt2, [Ns])]) :-
 feedback(sqrt2, [Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " with the square root stopping before ",
-	   \mmlm(Col, paren(color(sqrt2, Ns))), ". Please do not forget to take the ",
+	   \mmlm(Col, [paren(color(sqrt2, Ns)), "."]), " Please do not forget to take the ",
 	   "square root of the whole denominator."
          ].
 % Alternative Rückmeldung (hierfür müsste die Variable in der eckigen Klammer geändert werden): 
@@ -360,8 +355,9 @@ feedback(sqrt2, [Ns], Col, FB)
 % ". Please do not forget to take the square root of the whole denominator."
 
 hint(sqrt2, [_Ns], Col, FB)
- => FB = [ "The square root of the whole denomiator of the ",
-            \mmlm(Col, hyph(t, "ratio")), " should be taken." ].
+ => FB = [ "You need to take the square root of the whole denomiator in the formula for the ",
+            \mmlm(Col, hyph(t, "ratio."))
+         ].
 
 
 
@@ -426,7 +422,7 @@ feedback(ci_bounds, [_VR, _Box, _S2P, _N_VR, _N_Box, _Alpha], _Col, F)
 hint(ci_bounds, [VR, Box, S2P, N_VR, N_Box, Alpha], Col, H)
  => H = [ "The formula to calculate the lower and upper bound of the ",
           "confidence interval for the difference of group means is ",
-	  \mmlm(Col, pm(VR - Box, qt(1 - Alpha/2, N_VR + N_Box - 2) * sqrt(dot(S2P, frac(1, N_VR) + frac(1, N_Box)))))
+	  \mmlm(Col, [pm(VR - Box, qt(1 - Alpha/2, N_VR + N_Box - 2) * sqrt(dot(S2P, frac(1, N_VR) + frac(1, N_Box)))), "."])
         ].
 
 % Fourth step: Choose the correct quantile of the t-distribution
@@ -436,12 +432,12 @@ expert(cigroups, stage(2), X, Y, [step(expert, tquant, [Alpha])]) :-
 
 feedback(tquant, [Alpha], Col, F)
  => F = [ "Correctly used the ", \mmlm(Col, hyph(1 - Alpha/2, "quantile")),
-          "of the ", \mmlm(Col, hyph(t, "distribution"))
+          "of the ", \mmlm(Col, hyph(t, "distribution."))
         ].
 
 hint(tquant, [Alpha], Col, H)
  => H = [ "Make sure to use the ", \mmlm(Col, hyph(1 - Alpha/2, "quantile")),
-          "of the ", \mmlm(Col, hyph(t, "distribution"))
+          "of the ", \mmlm(Col, hyph(t, "distribution."))
         ].
 
 %
@@ -476,7 +472,7 @@ feedback(control, [VR, Box], Col, FB)
  => FB = [ "The sign of the result matches the ",
            "negative ", \mmlm(Col, hyph(t, "ratio,")), " ",
            "with ", \mmlm(Col, color(control, VR)), " subtracted ",
-           "from ", \mmlm(Col, [color(control, Box)]), ". Please keep in mind ",
+           "from ", \mmlm(Col, [color(control, Box), "."]), " Please keep in mind ",
 	   "that the control intervention must be subtracted from the tested ",
 	   "intervention."
          ]. 
@@ -497,14 +493,14 @@ buggy(cigroups, stage(1), From, To, [step(buggy, square, [S_A, S_B])]) :-
 feedback(square, [S_A, S_B], Col, FB)
  => FB = [ "The result matches the expression for the pooled variance without ",
 	   "the square of ", \mmlm(Col, color(square, S_A)), " and ", 
-	   \mmlm(Col, color(square, S_B)), ". Please do not forget the square of ",
+	   \mmlm(Col, [color(square, S_B), "."]), " Please do not forget the square of ",
 	   \mmlm(Col, color(square, S_A)), " and ", \mmlm(Col, color(square, S_B)),
 	   "when calculating the pooled variance."
          ].
 
 hint(square, [_S_A, _S_B], Col, FB)
  => FB = [ "Do not forget to use the square of the standard deviations ",
-           "when calculating the pooled variance ", \mmlm(Col, color(square, s2p)), "." 
+           "when calculating the pooled variance ", \mmlm(Col, [color(square, s2p), "."]) 
          ].
 
 
@@ -515,16 +511,15 @@ buggy(cigroups, stage(2), From, To, [step(buggy, school_1, [N_A, N_B])]) :-
 
 feedback(school_1, [A, B], Col, FB)
  => FB = [ "The result matches the the confidence interval for independent samples with ",
-	   \mmlm(Col, frac(1, color(school_1, color("black", A) + color("black", B)))),
-	   ". Please keep in mind that ", \mmlm(Col, color(school_1, 
+	   \mmlm(Col, [frac(1, color(school_1, color("black", A) + color("black", B))), "."]),
+	   " Please keep in mind that ", \mmlm(Col, [color(school_1, 
 		color("black", frac(1, A)) + color("black", frac(1, B)))
-		=\= frac(1, color(school_1, color("black", A) + color("black", B)))), "."
+		=\= frac(1, color(school_1, color("black", A) + color("black", B))), "."])
          ].
 
 hint(school_1, [A, B], Col, FB)
  => FB = [ "Do not forget that ",
-           \mmlm(Col, color(school_1, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school_1, color("black", A) + color("black", B)))), 
-           "."
+           \mmlm(Col, [color(school_1, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school_1, color("black", A) + color("black", B))), "."]) 
          ].
 
 
@@ -536,16 +531,15 @@ buggy(cigroups, stage(2), From, To, [step(buggy, school_2, [N_A, N_B])]) :-
 feedback(school_2, [A, B], Col, FB)
  => FB = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " for independent samples with ",
-	   \mmlm(Col, frac(1, color(school_2, color("black", A) + color("black", B)))),
-	   ". Please keep in mind that ", \mmlm(Col, color(school_2, 
+	   \mmlm(Col, [frac(1, color(school_2, color("black", A) + color("black", B))), "."]),
+	   " Please keep in mind that ", \mmlm(Col, [color(school_2, 
 		color("black", frac(1, A)) + color("black", frac(1, B)))
-		=\= frac(1, color(school_2, color("black", A) + color("black", B)))), "."
+		=\= frac(1, color(school_2, color("black", A) + color("black", B))), "."])
          ].
 
 hint(school_2, [A, B], Col, FB)
  => FB = [ "Do not forget that ",
-           \mmlm(Col, color(school_2, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school_2, color("black", A) + color("black", B)))), 
-           "."
+           \mmlm(Col, [color(school_2, color("black", frac(1, A)) + color("black", frac(1, B))) =\= frac(1, color(school_2, color("black", A) + color("black", B))), "."])
          ].
 
 
@@ -557,13 +551,13 @@ buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt1, [S2P, N_VR, N_Box])]) :-
 
 feedback(sqrt1, [S2P, N_VR, N_Box], Col, FB)
  => FB = [ "The result matches the confidence interval without square root around ", 
-           \mmlm(Col, color(sqrt1, dot(S2P, frac(1, N_VR) + frac(1, N_Box)))), ". Please do not forget the square root",
+           \mmlm(Col, [color(sqrt1, dot(S2P, frac(1, N_VR) + frac(1, N_Box))), "."]), " Please do not forget the square root",
            " around the denominator."
          ].
 
 hint(sqrt1, [S2P, N_VR, N_Box], Col, FB)
  => FB = [ "Do not forget the square root around ",
-           \mmlm(Col, color(sqrt1, dot(S2P, frac(1, N_VR) + frac(1, N_Box))))
+           \mmlm(Col, [color(sqrt1, dot(S2P, frac(1, N_VR) + frac(1, N_Box))), "."])
 	     ].
 
 
@@ -576,13 +570,13 @@ buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt2, [S2P, N_VR, N_Box])]) :-
 feedback(sqrt2, [S2P, N_VR, N_Box], Col, FB)
  => FB = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without ",
 	   "square root around ", 
-           \mmlm(Col, color(sqrt2, dot(S2P, frac(1, N_VR) + frac(1, N_Box)))), ". Please do not forget the square root",
+           \mmlm(Col, [color(sqrt2, dot(S2P, frac(1, N_VR) + frac(1, N_Box))), "."]), " Please do not forget the square root",
            " around the denominator."
          ].
 
 hint(sqrt2, [S2P, N_VR, N_Box], Col, FB)
  => FB = [ "Do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, dot(S2P, frac(1, N_VR) + frac(1, N_Box))))
+           \mmlm(Col, [color(sqrt2, dot(S2P, frac(1, N_VR) + frac(1, N_Box))), "."])
 	     ].
 
 
@@ -594,8 +588,8 @@ buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt3, [Ns])]) :-
 
 feedback(sqrt3, [Ns], Col, FB)
  => FB = [ "The result matches the confidence interval with the square root ",
-	   "stopping before ", \mmlm(Col, paren(color(sqrt3, Ns))), 
-	   ". Please do not forget to take the square root of the whole denominator."
+	   "stopping before ", \mmlm(Col, [paren(color(sqrt3, Ns)), "."]), 
+	   " Please do not forget to take the square root of the whole denominator."
 	 ].
 % Alternative Rückmeldung (hierfür müsste die Variable in der eckigen Klammer geändert werden): 
 % "The result matches the confidence interval with the square root only around ",
@@ -603,8 +597,7 @@ feedback(sqrt3, [Ns], Col, FB)
 % "square root of the whole denominator."
 
 hint(sqrt3, [_Ns], _Col, FB)
- => FB = [ "The square root of the whole denomiator should be taken." 
-	].
+ => FB = [ "The square root of the whole denomiator should be taken." ].
 
 % Buggy-Rule: Forget square root around sample size when calculating the t-statistic
 buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt4, [Ns])]) :-
@@ -615,7 +608,7 @@ buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt4, [Ns])]) :-
 feedback(sqrt4, [Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " with the square root stopping before ",
-	   \mmlm(Col, paren(color(sqrt4, Ns))), ". Please do not forget to take the ",
+	   \mmlm(Col, [paren(color(sqrt4, Ns)), "."]), " Please do not forget to take the ",
 	   "square root of the whole denominator."
 	 ].
 % Alternative Rückmeldung (hierfür müsste die Variable in der eckigen Klammer geändert werden): 
@@ -624,5 +617,4 @@ feedback(sqrt4, [Ns], Col, FB)
 % ". Please do not forget to take the square root of the whole denominator."
 
 hint(sqrt4, [_Ns], _Col, FB)
- => FB = [ "The square root of the whole denomiator should be taken." 
-	].
+ => FB = [ "The square root of the whole denomiator should be taken."].

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -53,7 +53,7 @@ render
       div(class(card), div(class('card-body'),
         [ h1(class('card-title'), "Phase II clinical study"),
           p(class('card-text'),
-            [ "Consider a clinical study on rumination-focused Cognitive ",
+            [ "Consider a clinical study on rumination-focused Cognitive",
               "Behavioral Therapy (rfCBT) with ",
               \mmlm(N = r(N)), " patients. The primary ",
               "outcome is the score on the Hamilton Rating Scale for ", 
@@ -143,7 +143,7 @@ feedback(tratio, [_D, _Mu, _S_D, _N], Col, F)
 
 hint(tratio, [D, Mu, S_D, N], Col, F)
  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " ",
-          "is ", \mmlm(Col, dfrac(D - Mu, S_D / sqrt(N))), "."
+          "is ", \mmlm(Col, [dfrac(D - Mu, S_D / sqrt(N)), "."])
         ].
 
 % Another correct result
@@ -158,7 +158,7 @@ feedback(abs_tratio, [_D, _Mu, _S_D, _N], Col, F)
 
 hint(abs_tratio, [D, Mu, S_D, N], Col, F)
  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")),
-          " is ", \mmlm(Col, abs(dfrac(D - Mu, S_D / sqrt(N)))), "."
+          " is ", \mmlm(Col, [abs(dfrac(D - Mu, S_D / sqrt(N))), "."])
         ].
 
 %
@@ -231,8 +231,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
  => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
-          "would be ", \mmlm(Col, dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))), "."
-        ].
+          "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."]) ].
 
 % The following mistake cannot occur in the paired t-test, but is again only
 % possible if the student has already made the wrong decision to calculate the
@@ -251,16 +250,16 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school1, [N1, N2])]) :-
 feedback(school1, [A, B], Col, F)
  => F = [ "The result matches the expression for the ",
 	   \mmlm(Col, hyph(t, "ratio"))," for independent samples with ",
-	   \mmlm(Col, frac(1, color(school, color("black", A) + color("black", B)))), 
-	   ". Please keep in mind that ", 
-	   \mmlm(Col, color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
-		 =\= frac(1, color(school, color("black", A) + color("black", B)))), "."
+	   \mmlm(Col, [frac(1, color(school, color("black", A) + color("black", B))), "."]), 
+	   " Please keep in mind that ", 
+	   \mmlm(Col, [color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
+		 =\= frac(1, color(school, color("black", A) + color("black", B))), "."])
         ].
 
 hint(school1, [N1, N2], Col, F)
  => F = [ "Please do not forget school ",
-          "math, ", \mmlm(Col, frac(1, color(school1, N1)) +
-            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2))), "."
+          "math, ", \mmlm(Col, [frac(1, color(school1, N1)) +
+            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2)), "."]) 
         ].
 
 % Buggy-Rule: Forgot school math (Same for N1 = N2)
@@ -271,13 +270,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school2, [N])]) :-
 feedback(school2, [N], Col, F)
  => F = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " for independent samples with ",
-	   \mmlm(Col, frac(1, color(school2, 2*N))), ". Please keep in mind that ",
-	   \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+	   \mmlm(Col, [frac(1, color(school2, 2*N)), "."]), " Please keep in mind that ",
+	   \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."]) 
         ].
 
 hint(school2, [N], Col, F)
  => F = [ "Please do not forget school math, ",
-          \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+          \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."])
         ].
 
 % Buggy-Rule: Forgot parentheses
@@ -296,9 +295,9 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
 	   "numerator and the denominator, ", \mmlm([error(correct) | Col], 
-	       dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-	           color(bug1, paren(color("#000000", S / SQRT_N))))),
-	   ". Please do not forget the parentheses around the numerator and the ",
+	       [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+	           color(bug1, paren(color("#000000", S / SQRT_N)))), "."]),
+	   " Please do not forget the parentheses around the numerator and the ",
 	   "denominator of a fraction."
         ].
 
@@ -306,8 +305,8 @@ hint(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "Do not forget the parentheses around the numerator and ",
           "the denominator of a fraction, ",
           \mmlm([error(correct) | Col],
-            dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-              color(bug1, paren(color("#000000", S / SQRT_N))))), "."
+            [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+              color(bug1, paren(color("#000000", S / SQRT_N)))), "."]) 
         ].
 
 % One challenging aspect of word problems ("Textaufgaben") is that students
@@ -324,7 +323,7 @@ buggy(tratio, stage(1), X, Y,
 feedback(t0, [D, T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the", 
 	   " T0 average ", \mmlm(Col, color(t0, T0)), " instead of the average", 
-	   " change score ", \mmlm(Col, color(t0, D)), ". Please insert the average",
+	   " change score ", \mmlm(Col, [color(t0, D), "."]), " Please insert the average",
 	   " change score ", \mmlm(Col, color(t0, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -345,7 +344,7 @@ feedback(s_t0, [S, S_T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), 
 	   " with the standard deviation for T0 ", \mmlm(Col, color(s_t0, S_T0)),
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_t0, S)), ". Please insert the standard deviation of the", 
+	   \mmlm(Col, [color(s_t0, S), "."]), " Please insert the standard deviation of the", 
 	   " change score ", \mmlm(Col, color(s_t0, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -366,7 +365,7 @@ buggy(tratio, stage(1), X, Y, [step(buggy, eot, [d, eot]),
 feedback(eot, [D, EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
            " EOT average ", \mmlm(Col, color(eot, EOT)), " instead of the ", 
-           "average change score ", \mmlm(Col, color(eot, D)), ". Please insert",
+           "average change score ", \mmlm(Col, [color(eot, D), "."]), " Please insert",
            " the average change score ",\mmlm(Col, color(eot, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -387,7 +386,7 @@ feedback(s_eot, [S, S_EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
 	   " standard deviation for EOT ", \mmlm(Col, color(s_eot, S_EOT)), 
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_eot, S)), ". Please insert the standard deviation of the",
+	   \mmlm(Col, [color(s_eot, S), "."]), " Please insert the standard deviation of the",
 	   " change score ", \mmlm(Col, color(s_eot, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -397,7 +396,7 @@ hint(s_eot, [_S, S_EOT], Col, F)
           "EOT ", \mmlm(Col, color(s_eot, S_EOT)), " into ",
           "the ", \mmlm(Col, hyph(t, "ratio.")), " Use the change scores ",
           "instead." 
-	].
+	      ].
 
 % Buggy-Rule: Use of n instead of sqrt(n)
 buggy(tratio, stage(2), X, Y, [step(buggy, sqrt1, [n])]) :-
@@ -406,13 +405,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt1, [n])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	  " square root around ", \mmlm(Col, color(sqrt1, N)), ". Please do not",
-	  " forget the square root around ", \mmlm(Col, color(sqrt1, N)), "."
+	  " square root around ", \mmlm(Col, [color(sqrt1, N), "."]), " Please do not",
+	  " forget the square root around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N)
@@ -423,13 +422,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 
 feedback(sqrt2, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	   " square root around ", \mmlm(Col, color(sqrt2, N)), ". Please do not",
-	   " forget the square root around ", \mmlm(Col, color(sqrt2, N)), "."
+	   " square root around ", \mmlm(Col, [color(sqrt2, N), "."]), " Please do not",
+	   " forget the square root around ", \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 hint(sqrt2, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt2, N)), "."
+          \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 %
@@ -473,7 +472,7 @@ expert(pvalue, stage(2), X, Y, [step(expert, tratio, [D, Mu, S_D, N])]) :-
 
 % hint(tratio, [D, Mu, S_D, N], Col, F)
 %  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " ",
-%           "is ", \mmlm(Col, dfrac(D - Mu, S_D / sqrt(N)))
+%           "is ", \mmlm(Col, [dfrac(D - Mu, S_D / sqrt(N)), "."])
 %         ].
 
 % Third step: Determine the two-tailed p-value
@@ -482,7 +481,7 @@ expert(pvalue, stage(2), X, Y, [step(expert, pvalue, [])]) :-
     Y = pval(2*pt(-abs(T), DF)).
 
 feedback(pvalue, [], Col, F)
- => F = [ "Correctly determined the two-tailed ", \mmlm(Col, hyph(p, "value")) ].
+ => F = [ "Correctly determined the two-tailed ", \mmlm(Col, hyph(p, "value.")) ].
 
 hint(pvalue, [], Col, F)
  => F = [ "The two-tailed ", \mmlm(Col, hyph(p, "value")), " must be determined." ].
@@ -532,7 +531,7 @@ feedback(ci_lower, [_D, _S_D, _N, _Alpha], _Col, F)
 hint(ci_lower, [D, S_D, N, Alpha], Col, H)
  => H = [ "The formula to calculate the lower and upper bound of the ",
           "confidence interval is ",
-	  \mmlm(Col, pm(D, qt(1 - Alpha/2, N-1) * S_D / sqrt(N))), "."
+	  \mmlm(Col, [pm(D, qt(1 - Alpha/2, N-1) * S_D / sqrt(N)), "."])
         ].
 
 % Third step: Choose the correct quantile of the t-distribution
@@ -605,7 +604,7 @@ feedback(spss, [Mu], Col, F)
         ].
 
 hint(spss, [Mu], Col, H)
- => H = [ "If you calculate the confindence intervall with SPSS keep in mind,",
+ => H = [ "If you calculate the confindence intervall with SPSS, keep in mind",
 	  " that SPSS subtracts ", \mmlm(Col, Mu), " from the two bounds of",
           " the CI (which must be undone)."
         ].
@@ -617,13 +616,13 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt1, [N])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the confidence interval without square root around ", 
-          \mmlm(Col, color(sqrt1, N)), ". Please do not forget the square root",
-          " around ", \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."]), " Please do not forget the square root",
+          " around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N) in the t-ratio
@@ -634,13 +633,13 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 feedback(sqrt2, [N], Col, FB)
  => FB = [ "The result matches the confidence interval based on the observed ",
 	   \mmlm(Col, hyph(t, "statistic.")), " without square root around ",
-	   \mmlm(Col, color(sqrt2, N)), " Please do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+	   \mmlm(Col, [color(sqrt2, N), "."]), " Please do not forget the square root around ",
+           \mmlm(Col, [color(sqrt2, N), "."])
          ].
 
 hint(sqrt2, [N], Col, FB)
  => FB = [ "Do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+           \mmlm(Col, [color(sqrt2, N), "."])
          ]. 
 
 

--- a/tpaired1t.pl
+++ b/tpaired1t.pl
@@ -8,7 +8,7 @@
 :- use_module(mathml).
 
 :- use_module(navbar).
-navbar:page(tpaired1t, ["paired ", i(t), "-test onetailed"]).
+navbar:page(tpaired1t, ["paired ", i(t), "-test onetailed (1)"]).
 
 task(tratio).
 task(pvalue).
@@ -46,15 +46,6 @@ rint:r_hook(pt(_T, _DF)).
 rint:r_hook(qt(_P, _DF)).
  
 interval:monotonical(pt(+, /)).
-
-% The parameter 'incr' from R should determine whether an increment or a decrease of the values is good.
-% Now the question is, if there should be an additional task in the navigation bar 
-% with a different scale for the case that an increment is good, for example with 
-% some performance test, in which case the terms in the numerator of the t-formula have 
-% to be switched (Mu - D), or if it should be selected randomly.
-% Since the two tasks (one-tailed increment good-increment bad) share most of the components
-% one could also ask, if there is a more elegant solution than duplicating the source-code and making
-% small changes, as it is not best programming practice. 
 
 
 % Task description
@@ -156,7 +147,7 @@ feedback(tratio, [_D, _Mu, _S_D, _N], Col, F)
 
 hint(tratio, [D, Mu, S_D, N], Col, F)
  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " ",
-          "is ", \mmlm(Col, dfrac(D - Mu, S_D / sqrt(N))), "."
+          "is ", \mmlm(Col, [dfrac(D - Mu, S_D / sqrt(N)), "."])
         ].
 
 
@@ -237,7 +228,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
  => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
-          "would be ", \mmlm(Col, dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))), "."
+          "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."])
         ].
 
 % The following mistake cannot occur in the paired t-test, but is again only
@@ -257,16 +248,16 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school1, [N1, N2])]) :-
 feedback(school1, [A, B], Col, F)
  => F = [ "The result matches the expression for the ",
 	   \mmlm(Col, hyph(t, "ratio"))," for independent samples with ",
-	   \mmlm(Col, frac(1, color(school, color("black", A) + color("black", B)))), 
-	   ". Please keep in mind that ", 
-	   \mmlm(Col, color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
-		 =\= frac(1, color(school, color("black", A) + color("black", B)))), "."
+	   \mmlm(Col, [frac(1, color(school, color("black", A) + color("black", B))), "."]), 
+	   " Please keep in mind that ", 
+	   \mmlm(Col, [color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
+		 =\= frac(1, color(school, color("black", A) + color("black", B))), "."])
         ].
 
 hint(school1, [N1, N2], Col, F)
  => F = [ "Please do not forget school ",
-          "math, ", \mmlm(Col, frac(1, color(school1, N1)) +
-            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2))), "."
+          "math, ", \mmlm(Col, [frac(1, color(school1, N1)) +
+            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2)), "."])
         ].
 
 % Buggy-Rule: Forgot school math (Same for N1 = N2)
@@ -277,13 +268,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school2, [N])]) :-
 feedback(school2, [N], Col, F)
  => F = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " for independent samples with ",
-	   \mmlm(Col, frac(1, color(school2, 2*N))), ". Please keep in mind that ",
-	   \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+	   \mmlm(Col, [frac(1, color(school2, 2*N)), "."]), " Please keep in mind that ",
+	   \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."])
         ].
 
 hint(school2, [N], Col, F)
  => F = [ "Please do not forget school math, ",
-          \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+          \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."])
         ].
 
 % Buggy-Rule: Forgot parentheses
@@ -302,9 +293,9 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
 	   "numerator and the denominator, ", \mmlm([error(correct) | Col], 
-	       dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-	           color(bug1, paren(color("#000000", S / SQRT_N))))),
-	   ". Please do not forget the parentheses around the numerator and the ",
+	       [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+	           color(bug1, paren(color("#000000", S / SQRT_N)))), "."]),
+	   " Please do not forget the parentheses around the numerator and the ",
 	   "denominator of a fraction."
         ].
 
@@ -312,8 +303,8 @@ hint(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "Do not forget the parentheses around the numerator and ",
           "the denominator of a fraction, ",
           \mmlm([error(correct) | Col],
-            dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-              color(bug1, paren(color("#000000", S / SQRT_N))))), "."
+            [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+              color(bug1, paren(color("#000000", S / SQRT_N)))), "."])
         ].
 
 % One challenging aspect of word problems ("Textaufgaben") is that students
@@ -330,7 +321,7 @@ buggy(tratio, stage(1), X, Y,
 feedback(t0, [D, T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the", 
 	   " T0 average ", \mmlm(Col, color(t0, T0)), " instead of the average", 
-	   " change score ", \mmlm(Col, color(t0, D)), ". Please insert the average",
+	   " change score ", \mmlm(Col, [color(t0, D), "."]), " Please insert the average",
 	   " change score ", \mmlm(Col, color(t0, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -351,7 +342,7 @@ feedback(s_t0, [S, S_T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), 
 	   " with the standard deviation for T0 ", \mmlm(Col, color(s_t0, S_T0)),
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_t0, S)), ". Please insert the standard deviation of the", 
+	   \mmlm(Col, [color(s_t0, S), "."]), " Please insert the standard deviation of the", 
 	   " change score ", \mmlm(Col, color(s_t0, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -372,7 +363,7 @@ buggy(tratio, stage(1), X, Y, [step(buggy, eot, [d, eot]),
 feedback(eot, [D, EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
            " EOT average ", \mmlm(Col, color(eot, EOT)), " instead of the ", 
-           "average change score ", \mmlm(Col, color(eot, D)), ". Please insert",
+           "average change score ", \mmlm(Col, [color(eot, D), "."]), " Please insert",
            " the average change score ",\mmlm(Col, color(eot, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -393,7 +384,7 @@ feedback(s_eot, [S, S_EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
 	   " standard deviation for EOT ", \mmlm(Col, color(s_eot, S_EOT)), 
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_eot, S)), ". Please insert the standard deviation of the",
+	   \mmlm(Col, [color(s_eot, S), "."]), " Please insert the standard deviation of the",
 	   " change score ", \mmlm(Col, color(s_eot, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -412,13 +403,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt1, [n])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	  " square root around ", \mmlm(Col, color(sqrt1, N)), ". Please do not",
-	  " forget the square root around ", \mmlm(Col, color(sqrt1, N)), "."
+	  " square root around ", \mmlm(Col, [color(sqrt1, N), "."]), " Please do not",
+	  " forget the square root around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N)
@@ -429,13 +420,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 
 feedback(sqrt2, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	   " square root around ", \mmlm(Col, color(sqrt2, N)), ". Please do not",
-	   " forget the square root around ", \mmlm(Col, color(sqrt2, N)), "."
+	   " square root around ", \mmlm(Col, [color(sqrt2, N), "."]), " Please do not",
+	   " forget the square root around ", \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 hint(sqrt2, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt2, N)), "."
+          \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 
@@ -493,7 +484,7 @@ expert(pvalue, stage(2), X, Y, [step(expert, pvalue, [])]) :-
     Y = pval(pt(-T, DF)).
 
 feedback(pvalue, [], Col, F)
- => F = [ "Correctly determined the one-tailed ", \mmlm(Col, hyph(p, "value")) ].
+ => F = [ "Correctly determined the one-tailed ", \mmlm(Col, hyph(p, "value.")) ].
 
 hint(pvalue, [], Col, F)
  => F = [ "The one-tailed ", \mmlm(Col, hyph(p, "value")), " must be determined." ].
@@ -509,13 +500,13 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, wrongtail, [DF])]) :-
      Y = pval(pt(T, DF)).
 
 feedback(wrongtail, [DF], Col, F)
- => F = [ "The result matches the left-sided ", \mmlm(Col, hyph(p, "value")), 
-          ". Please make sure to use the area of the ", \mmlm(Col, hyph(t(DF), "distribution")),
-          " on the right side of the calculated ", \mmlm(Col, hyph(t, "value")), "."
+ => F = [ "The result matches the left-sided ", \mmlm(Col, hyph(p, "value.")), 
+          " Please make sure to use the area of the ", \mmlm(Col, hyph(t(DF), "distribution")),
+          " on the right side of the calculated ", \mmlm(Col, hyph(t, "value."))
         ].
 
 hint(wrongtail, [DF], Col, F)
- => F = [ "Use the upper tail of the ", \mmlm(Col, hyph(t(DF), "distribution")), "."].
+ => F = [ "Use the upper tail of the ", \mmlm(Col, hyph(t(DF), "distribution."))].
 
 
 % Buggy-Rule: used the wrong t-value and/or degrees of freedoms
@@ -528,13 +519,13 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, wrong, [T, DF])]) :-
 feedback(wrong, [T, DF], Col, F)
  => F = [ "The result is not the ", \mmlm(Col, hyph(p, "value")), 
 	        " associated with the calculated ", \mmlm(Col, hyph(t, "value")), \mmlm(T = r(T)), 
-          " and degrees of freedom ", \mmlm(DF = r(DF)), ".", 
+          " and degrees of freedom ", \mmlm([DF = r(DF), "."]), 
           " Please make sure to look at the correct column and row on the table of the ", 
-          \mmlm(Col, hyph(t, "distribution")), "."].
+          \mmlm(Col, hyph(t, "distribution."))].
 
 hint(wrong, [_T, _DF], Col, F)
  => F = [ "Look at the correct column and row on the table of the ", 
-          \mmlm(Col, hyph(t, "distribution")), "."].
+          \mmlm(Col, hyph(t, "distribution."))].
 
 
 
@@ -568,17 +559,18 @@ hint(paired, [], Col, H)
 intermediate(cipaired, quant).
 expert(cipaired, stage(2), X, Y, [step(expert, ci_lower, [D, S_D, N, Alpha])]) :-
     X = paired(D, Mu, S_D, N, Alpha),
-    Y = hdrs(pm(D, dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
+    Y = hdrs((D - dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
 
 feedback(ci_lower, [_D, _S_D, _N, _Alpha], _Col, F)					
- => F = [ "Correctly identified the formula for the upper and lower bound of ",
-           "the confidence interval for a mean value." 
+ => F = [ "Correctly identified the formula for the lower bound of ",
+           "the confidence interval for a mean value in a ",
+            \mmlm(hyph(t, "test."))
         ].
 
-hint(ci_lower, [D, S_D, N, Alpha], Col, H)
- => H = [ "The formula to calculate the lower and upper bound of the ",
+hint(ci_lower, [D, S_D, N, Alpha], _Col, H)
+ => H = [ "The formula to calculate the lower a bound of the ",
           "confidence interval is ",
-	  \mmlm(Col, pm(D, qt(1 - Alpha, N-1) * S_D / sqrt(N))), "."
+	  \mmlm([(D - qt(1 - Alpha, N-1) * S_D / sqrt(N)), "."])
         ].
 
 % Third step: Choose the correct quantile of the t-distribution
@@ -626,7 +618,7 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, qnorm, [N, Alpha])]) :-
 
 feedback(qnorm, [N, Alpha], Col, F)
  => F = [ "The result matches the confidence interval based on the standard ",
-          "Normal distribution. ",
+          "normal distribution. ",
           "Please insert the quantile of the ", \mmlm(Col, hyph(t, "distribution")),
           \mmlm(Col, color(qnorm, qt(1 - Alpha, N - 1))), " into ",
           "the formula for the confidence interval."
@@ -651,7 +643,7 @@ feedback(spss, [Mu], Col, F)
         ].
 
 hint(spss, [Mu], Col, H)
- => H = [ "If you calculate the confindence intervall with SPSS keep in mind,",
+ => H = [ "If you calculate the confindence intervall with SPSS, keep in mind",
 	  " that SPSS subtracts ", \mmlm(Col, Mu), " from the two bounds of",
           " the CI (which must be undone)."
         ].
@@ -663,13 +655,13 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt1, [N])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the confidence interval without square root around ", 
-          \mmlm(Col, color(sqrt1, N)), ". Please do not forget the square root",
-          " around ", \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."]), " Please do not forget the square root",
+          " around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N) in the t-ratio
@@ -680,13 +672,13 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 feedback(sqrt2, [N], Col, FB)
  => FB = [ "The result matches the confidence interval based on the observed ",
 	   \mmlm(Col, hyph(t, "statistic.")), " without square root around ",
-	   \mmlm(Col, color(sqrt2, N)), " Please do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+	   \mmlm(Col, [color(sqrt2, N), "."]), " Please do not forget the square root around ",
+           \mmlm(Col, [color(sqrt2, N), "."])
          ].
 
 hint(sqrt2, [N], Col, FB)
  => FB = [ "Do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+           \mmlm(Col, [color(sqrt2, N), "."])
          ]. 
 
 

--- a/tpaired1tlow.pl
+++ b/tpaired1tlow.pl
@@ -8,7 +8,7 @@
 :- use_module(mathml).
 
 :- use_module(navbar).
-navbar:page(tpaired1tlow, ["paired ", i(t), "-test onetailed"]).
+navbar:page(tpaired1tlow, ["paired ", i(t), "-test onetailed (2)"]).
 
 task(tratio).
 task(pvalue).
@@ -152,7 +152,7 @@ feedback(tratio, [_D, _Mu, _S_D, _N], Col, F)
 
 hint(tratio, [D, Mu, S_D, N], Col, F)
  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " ",
-          "is ", \mmlm(Col, dfrac(D - Mu, S_D / sqrt(N))), "."
+          "is ", \mmlm(Col, [dfrac(D - Mu, S_D / sqrt(N)), "."])
         ].
 
 
@@ -233,7 +233,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
  => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
-          "would be ", \mmlm(Col, dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))), "."
+          "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."])
         ].
 
 % The following mistake cannot occur in the paired t-test, but is again only
@@ -253,16 +253,16 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school1, [N1, N2])]) :-
 feedback(school1, [A, B], Col, F)
  => F = [ "The result matches the expression for the ",
 	   \mmlm(Col, hyph(t, "ratio"))," for independent samples with ",
-	   \mmlm(Col, frac(1, color(school, color("black", A) + color("black", B)))), 
-	   ". Please keep in mind that ", 
-	   \mmlm(Col, color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
-		 =\= frac(1, color(school, color("black", A) + color("black", B)))), "."
+	   \mmlm(Col, [frac(1, color(school, color("black", A) + color("black", B))), "."]), 
+	   " Please keep in mind that ", 
+	   \mmlm(Col, [color(school, color("black", frac(1, A)) + color("black", frac(1, B)))
+		 =\= frac(1, color(school, color("black", A) + color("black", B))), "."])
         ].
 
 hint(school1, [N1, N2], Col, F)
  => F = [ "Please do not forget school ",
-          "math, ", \mmlm(Col, frac(1, color(school1, N1)) +
-            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2))), "."
+          "math, ", \mmlm(Col, [frac(1, color(school1, N1)) +
+            frac(1, color(school1, N2)) =\= frac(1, color(school1, N1+N2)), "."])
         ].
 
 % Buggy-Rule: Forgot school math (Same for N1 = N2)
@@ -273,13 +273,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, school2, [N])]) :-
 feedback(school2, [N], Col, F)
  => F = [ "The result matches the expression for the ", 
 	   \mmlm(Col, hyph(t, "ratio")), " for independent samples with ",
-	   \mmlm(Col, frac(1, color(school2, 2*N))), ". Please keep in mind that ",
-	   \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+	   \mmlm(Col, [frac(1, color(school2, 2*N)), "."]), " Please keep in mind that ",
+	   \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."])
         ].
 
 hint(school2, [N], Col, F)
  => F = [ "Please do not forget school math, ",
-          \mmlm(Col, frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N))), "."
+          \mmlm(Col, [frac(1, color(school2, N)) + frac(1, color(school2, N)) =\= frac(1, color(school2, 2*N)), "."])
         ].
 
 % Buggy-Rule: Forgot parentheses
@@ -298,9 +298,9 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
 	   "numerator and the denominator, ", \mmlm([error(correct) | Col], 
-	       dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-	           color(bug1, paren(color("#000000", S / SQRT_N))))),
-	   ". Please do not forget the parentheses around the numerator and the ",
+	       [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+	           color(bug1, paren(color("#000000", S / SQRT_N)))), "."]),
+	   " Please do not forget the parentheses around the numerator and the ",
 	   "denominator of a fraction."
         ].
 
@@ -308,8 +308,8 @@ hint(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "Do not forget the parentheses around the numerator and ",
           "the denominator of a fraction, ",
           \mmlm([error(correct) | Col],
-            dfrac(color(bug1, paren(color("#000000", D - Mu))), 
-              color(bug1, paren(color("#000000", S / SQRT_N))))), "."
+            [dfrac(color(bug1, paren(color("#000000", D - Mu))), 
+              color(bug1, paren(color("#000000", S / SQRT_N)))), "."])
         ].
 
 % One challenging aspect of word problems ("Textaufgaben") is that students
@@ -326,7 +326,7 @@ buggy(tratio, stage(1), X, Y,
 feedback(t0, [D, T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the", 
 	   " T0 average ", \mmlm(Col, color(t0, T0)), " instead of the average", 
-	   " change score ", \mmlm(Col, color(t0, D)), ". Please insert the average",
+	   " change score ", \mmlm(Col, [color(t0, D), "."]), " Please insert the average",
 	   " change score ", \mmlm(Col, color(t0, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -347,7 +347,7 @@ feedback(s_t0, [S, S_T0], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), 
 	   " with the standard deviation for T0 ", \mmlm(Col, color(s_t0, S_T0)),
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_t0, S)), ". Please insert the standard deviation of the", 
+	   \mmlm(Col, [color(s_t0, S), "."]), " Please insert the standard deviation of the", 
 	   " change score ", \mmlm(Col, color(s_t0, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -368,7 +368,7 @@ buggy(tratio, stage(1), X, Y, [step(buggy, eot, [d, eot]),
 feedback(eot, [D, EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
            " EOT average ", \mmlm(Col, color(eot, EOT)), " instead of the ", 
-           "average change score ", \mmlm(Col, color(eot, D)), ". Please insert",
+           "average change score ", \mmlm(Col, [color(eot, D), "."]), " Please insert",
            " the average change score ",\mmlm(Col, color(eot, D)), " into the ",
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -389,7 +389,7 @@ feedback(s_eot, [S, S_EOT], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " with the",
 	   " standard deviation for EOT ", \mmlm(Col, color(s_eot, S_EOT)), 
 	   " instead of the standard deviation of the change score ", 
-	   \mmlm(Col, color(s_eot, S)), ". Please insert the standard deviation of the",
+	   \mmlm(Col, [color(s_eot, S), "."]), " Please insert the standard deviation of the",
 	   " change score ", \mmlm(Col, color(s_eot, S)), " into the ", 
 	   \mmlm(Col, hyph(t, "ratio."))
 	].
@@ -408,13 +408,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt1, [n])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	  " square root around ", \mmlm(Col, color(sqrt1, N)), ". Please do not",
-	  " forget the square root around ", \mmlm(Col, color(sqrt1, N)), "."
+	  " square root around ", \mmlm(Col, [color(sqrt1, N), "."]), " Please do not",
+	  " forget the square root around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N)
@@ -425,13 +425,13 @@ buggy(tratio, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 
 feedback(sqrt2, [N], Col, F)
  => F = [ "The result matches the ", \mmlm(Col, hyph(t, "ratio")), " without", 
-	   " square root around ", \mmlm(Col, color(sqrt2, N)), ". Please do not",
-	   " forget the square root around ", \mmlm(Col, color(sqrt2, N)), "."
+	   " square root around ", \mmlm(Col, [color(sqrt2, N), "."]), " Please do not",
+	   " forget the square root around ", \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 hint(sqrt2, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt2, N)), "."
+          \mmlm(Col, [color(sqrt2, N), "."])
         ].
 
 
@@ -487,7 +487,7 @@ expert(pvalue, stage(2), X, Y, [step(expert, tratio, [D, Mu, S_D, N])]) :-
 
 % hint(tratio, [D, Mu, S_D, N], Col, F)
 %  => F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " ",
-%           "is ", \mmlm(Col, dfrac(D - Mu, S_D / sqrt(N)))
+%           "is ", \mmlm(Col, [dfrac(D - Mu, S_D / sqrt(N)), "."])
 %         ].
 
 % Third step: Determine the one-tailed p-value
@@ -496,7 +496,7 @@ expert(pvalue, stage(2), X, Y, [step(expert, pvalue, [])]) :-
     Y = pval(pt(-T, DF)).
 
 feedback(pvalue, [], Col, F)
- => F = [ "Correctly determined the one-tailed ", \mmlm(Col, hyph(p, "value")) ].
+ => F = [ "Correctly determined the one-tailed ", \mmlm(Col, hyph(p, "value.")) ].
 
 hint(pvalue, [], Col, F)
  => F = [ "The one-tailed ", \mmlm(Col, hyph(p, "value")), " must be determined." ].
@@ -512,13 +512,13 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, wrongtail, [DF])]) :-
      Y = pval(pt(T, DF)).
 
 feedback(wrongtail, [DF], Col, F)
- => F = [ "The result matches the left-sided ", \mmlm(Col, hyph(p, "value")), 
-          ". Please make sure to use the area of the ", \mmlm(Col, hyph(t(DF), "distribution")),
-          " on the right side of the calculated ", \mmlm(Col, hyph(t, "value")), "."
+ => F = [ "The result matches the left-sided ", \mmlm(Col, hyph(p, "value.")), 
+          " Please make sure to use the area of the ", \mmlm(Col, hyph(t(DF), "distribution")),
+          " on the right side of the calculated ", \mmlm(Col, hyph(t, "value."))
         ].
 
 hint(wrongtail, [DF], Col, F)
- => F = [ "Use the upper tail of the ", \mmlm(Col, hyph(t(DF), "distribution")), "."].
+ => F = [ "Use the upper tail of the ", \mmlm(Col, hyph(t(DF), "distribution."))].
 
 
 % Buggy-Rule: used the wrong t-value and/or degrees of freedoms
@@ -531,13 +531,13 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, wrong, [T, DF])]) :-
 feedback(wrong, [T, DF], Col, F)
  => F = [ "The result is not the ", \mmlm(Col, hyph(p, "value")), 
 	        " associated with the calculated ", \mmlm(Col, hyph(t, "value")), \mmlm(T = r(T)), 
-          " and degrees of freedom ", \mmlm(DF = r(DF)), ".", 
+          " and degrees of freedom ", \mmlm([DF = r(DF), "."]), 
           " Please make sure to look at the correct column and row on the table of the ", 
-          \mmlm(Col, hyph(t, "distribution")), "."].
+          \mmlm(Col, hyph(t, "distribution."))].
 
 hint(wrong, [_T, _DF], Col, F)
  => F = [ "Look at the correct column and row on the table of the ", 
-          \mmlm(Col, hyph(t, "distribution")), "."].
+          \mmlm(Col, hyph(t, "distribution."))].
 
 
 
@@ -573,17 +573,18 @@ hint(paired, [], Col, H)
 intermediate(cipaired, quant).
 expert(cipaired, stage(2), X, Y, [step(expert, ci_lower, [D, S_D, N, Alpha])]) :-
     X = paired(D, Mu, S_D, N, Alpha),
-    Y = hdrs(pm(D, dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
+    Y = hdrs(D - (dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
 
-feedback(ci_lower, [_D, _S_D, _N, _Alpha], _Col, F)					
- => F = [ "Correctly identified the formula for the upper and lower bound of ",
-           "the confidence interval for a mean value." 
+feedback(ci_lower, [_D, _S_D, _N, _Alpha], Col, F)					
+ => F = [ "Correctly identified the formula for the lower bound of ",
+           "the confidence interval for a mean value in a ",
+            \mmlm(Col, hyph(t, "test."))
         ].
 
-hint(ci_lower, [D, S_D, N, Alpha], Col, H)
- => H = [ "The formula to calculate the lower and upper bound of the ",
+hint(ci_lower, [D, S_D, N, Alpha], _Col, H)
+ => H = [ "The formula to calculate the lower  bound of the ",
           "confidence interval is ",
-	  \mmlm(Col, pm(D, qt(1 - Alpha, N-1) * S_D / sqrt(N))), "."
+	  \mmlm([(D - (qt(1 - Alpha, N-1) * S_D / sqrt(N))), "."])
         ].
 
 % Third step: Choose the correct quantile of the t-distribution
@@ -631,7 +632,7 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, qnorm, [N, Alpha])]) :-
 
 feedback(qnorm, [N, Alpha], Col, F)
  => F = [ "The result matches the confidence interval based on the standard ",
-          "Normal distribution. ",
+          "normal distribution. ",
           "Please insert the quantile of the ", \mmlm(Col, hyph(t, "distribution")),
           \mmlm(Col, color(qnorm, qt(1 - Alpha, N - 1))), " into ",
           "the formula for the confidence interval."
@@ -656,7 +657,7 @@ feedback(spss, [Mu], Col, F)
         ].
 
 hint(spss, [Mu], Col, H)
- => H = [ "If you calculate the confindence intervall with SPSS keep in mind,",
+ => H = [ "If you calculate the confindence intervall with SPSS, keep in mind",
 	  " that SPSS subtracts ", \mmlm(Col, Mu), " from the two bounds of",
           " the CI (which must be undone)."
         ].
@@ -668,13 +669,13 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt1, [N])]) :-
 
 feedback(sqrt1, [N], Col, F)
  => F = [ "The result matches the confidence interval without square root around ", 
-          \mmlm(Col, color(sqrt1, N)), ". Please do not forget the square root",
-          " around ", \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."]), " Please do not forget the square root",
+          " around ", \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 hint(sqrt1, [N], Col, F)
  => F = [ "Do not forget the square root around ",
-          \mmlm(Col, color(sqrt1, N)), "."
+          \mmlm(Col, [color(sqrt1, N), "."])
         ].
 
 % Buggy-Rule: Use of N instead of sqrt(N) in the t-ratio
@@ -684,14 +685,14 @@ buggy(cipaired, stage(2), X, Y, [step(buggy, sqrt2, [N])]) :-
 
 feedback(sqrt2, [N], Col, FB)
  => FB = [ "The result matches the confidence interval based on the observed ",
-	   \mmlm(Col, hyph(t, "statistic.")), " without square root around ",
-	   \mmlm(Col, color(sqrt2, N)), " Please do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+	   \mmlm(Col, hyph(t, "statistic")), " without square root around ",
+	   \mmlm(Col, [color(sqrt2, N), "."]), " Please do not forget the square root around ",
+           \mmlm(Col, [color(sqrt2, N), "."])
          ].
 
 hint(sqrt2, [N], Col, FB)
  => FB = [ "Do not forget the square root around ",
-           \mmlm(Col, color(sqrt2, N)), "."
+           \mmlm(Col, [color(sqrt2, N), "."])
          ]. 
 
 

--- a/ztrans.pl
+++ b/ztrans.pl
@@ -50,8 +50,7 @@ intermediate(ztrans, zcalc).
 expert(ztrans, stage(1), From, To, [step(expert, allinone, [])]) :-
     From = item(X, Mu, Sigma),
     To = { '<-'(z, zcalc(X, Mu, Sigma)) ;
-           '<-'(p, pnorm_(z)) ; 
-           p
+           '<-'(p, pnorm_(z)) 
          }.
 
 feedback(allinone, [], _Col, FB) =>
@@ -67,10 +66,10 @@ expert(ztrans, stage(1), From, To, [step(expert, zcalc, [X, Mu, Sigma])]) :-
     To = dfrac(X - Mu, Sigma).
 
 feedback(zcalc, [_X, _Mu, _Sigma], _Col, FB) =>
-    FB = [ "Good Job! You correctly calculated Z." ].
+    FB = [ "You correctly calculated Z." ].
 
 hint(zcalc, [X, Mu, Sigma], Col, FB) =>
-    FB = [ "To calculate the z-value, use " , \mmlm(Col, dfrac(X - Mu, Sigma)) ].
+    FB = [ "To calculate the z-value, use " , \mmlm(Col, [dfrac(X - Mu, Sigma), "."]) ].
 
 % Expert rule (correct tail)
 expert(ztrans, stage(2), From, To, [step(expert, correct_tail, [Z])]) :-
@@ -117,7 +116,7 @@ buggy(ztrans, stage(1), From, To, [step(buggy, swap, [mu, sigma])]) :-
 
 feedback(swap, [Mu, Sigma], Col, FB) =>
     FB = [ "You swapped ", \mmlm(Col, color(swap, Mu)), " and ", 
-	   \mmlm(Col, color(swap, Sigma)) ].
+	   \mmlm(Col, [color(swap, Sigma), "."]) ].
 
 hint(swap, [Mu, Sigma], Col, FB) =>
     FB = [ "Try using ", \mmlm(Col, color(swap, Mu)), " and ", 
@@ -140,7 +139,7 @@ buggy(ztrans, stage(2), From, To, [step(buggy, xp, []), depends(xp2)]) :-
    To = omit_right(xp, dfrac(omit_right(xp, x - mu), sigma)).
 
 feedback(xp, [], Col, FB) =>
-    FB = [ "The z-value is calculated by calculating ", \mmlm(Col, dfrac(x - mu, sigma)) ].
+    FB = [ "The z-value is calculated by using the formula ", \mmlm(Col, [dfrac(x - mu, sigma), "."]) ].
 
 hint(xp, [], _Col, FB) =>
     FB = [ "Remember to calculate the z-value." ].
@@ -151,8 +150,8 @@ buggy(ztrans, stage(2), From, To, [step(buggy, xp2, []), depends(xp)]) :-
     To = instead(xp2, z/100, pnorm(z)).
 
 feedback(xp2, [], _Col, FB) =>
-    FB = [ "von Matthias hinzugefuegt." ].
+    FB = [ "You mistakenly divided the z-value by 100 instead of retrieving the value from the normal distribution" ].
 
-hint(xp2, [], Col, FB) =>
-    FB = [ "von Matthias hinzugefuegt ", \mmlm(Col, dfrac(x - mu, sigma)) ].
+hint(xp2, [], _Col, FB) =>
+    FB = [ "Do not divide the z-value by 100, use the normal distribution instead" ].
 

--- a/ztrans2.pl
+++ b/ztrans2.pl
@@ -27,11 +27,11 @@ render
       [ div(class(card), div(class('card-body'),
         [ h1(class('card-title'), "Normal distribution"),
           p(class('card-text'), 
-            [ "Let ", \mmlm(x), " follow a Normal distribution with ",
+            [ "Let ", \mmlm(x), " follow a normal distribution with ",
               "expectation ", \mmlm([digits(0)], Mu = r(mu)), " and ",
               "standard deviation ", \mmlm([digits(0)], [Sigma = r(sigma), "."]),
               "A table of the standard ",
-              "Normal distribution is found below."
+              "normal distribution is found below."
             ])]))]).
 
 task(ztrans)
@@ -47,8 +47,7 @@ intermediate(ztrans, qnorm_).
 expert(ztrans, stage(2), From, To, [step(expert, steps, [])]) :-
     From = item(P, Mu, Sigma),
     To = { '<-'( z, qnorm_(1 - dfrac(P, 100))) ;
-           '<-'(x, z * Sigma + Mu) ;
-           x
+           '<-'(x, z * Sigma + Mu)
          }.
 
 feedback(steps, [], Col, FB) =>
@@ -65,10 +64,10 @@ expert(ztrans, stage(2), From, To, [step(expert, correct_tail, [])]) :-
     To = qnorm(P).
 
 feedback(correct_tail, [], _Col, FB) =>
-    FB = [ "Your response matches the lower tail of the Normal distribution." ].
+    FB = [ "Your response matches the lower tail of the normal distribution." ].
 
 hint(correct_tail, [], _Col, FB) =>
-    FB = [ "Try using the upper tail of the Normal distribution." ].
+    FB = [ "Try using the upper tail of the normal distribution." ].
 
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~%
 % wrong_tail
@@ -80,11 +79,11 @@ buggy(ztrans, stage(2), From, To, [step(buggy, wrong_tail, [])]) :-
     To = qnorm(instead(wrong_tail, P, 1 - P)).
 
 feedback(wrong_tail, [], _Col, FB) =>
-    FB = [ "Your response matches the lower, not the upper tail of the Normal ",
+    FB = [ "Your response matches the lower insteada of the upper tail of the normal ",
            "distribution." ].
 
 hint(wrong_tail, [], _Col, FB) =>
-    FB = [ "Make sure to use the correct tail of the Normal distribution." ].
+    FB = [ "Make sure to use the correct tail of the normal distribution." ].
 
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~%
 % Buggy Rule (swap) Mu and Sigma were swapped.
@@ -94,7 +93,7 @@ buggy(ztrans, stage(2), From, To, [step(buggy, swap, [mu, Sigma])]) :-
 
 feedback(swap, [Mu, Sigma], Col, FB) =>
     FB = [ "You swapped ", \mmlm(Col, color(swap, Mu)), " and ",
-	   \mmlm(Col, color(swap, Sigma)) ].
+	   \mmlm(Col, [color(swap, Sigma), "."]) ].
 
 hint(swap, [Mu, Sigma], Col, FB) =>
     FB = [ "Try using ", \mmlm(Col, color(swap, Mu)), " and ", 
@@ -151,8 +150,8 @@ buggy(ztrans, stage(2), From, To, [step(buggy, zx, [z, sigma, mu])]) :-
     To = instead(zx, z , From).
 
 feedback(zx, [z, sigma, mu], _Col, FB) =>
-    FB = [ "To complete the exercise successfully you have to do the second calculation aswell." ].
+    FB = [ "To complete the exercise successfully, you have to perform the second calculation as well." ].
 
 hint(zx, [z, sigma, mu], Col, FB) =>
-    FB = [ \mmlm(Col, color(zx, z)), "is the correct answer of the first equation. To continue calculate ", \mmlm(Col, color(zx, z * sigma + mu)), "." ].
+    FB = [ \mmlm(Col, color(zx, z)), "is the correct answer of the first equation. To continue, you need to calculate ", \mmlm(Col, [color(zx, z * sigma + mu), "."]) ].
 


### PR DESCRIPTION
-Corrected various typing errors and the formatting of the dot '.' at the end of a formula.

The files relative to the tasks about the baseline covariate and the binomial have not been modified, because they do not load correctly. This bug needs to be fixed first.