### PR TITLE
Renaming mathml predicates

### DIFF
--- a/baseline.pl
+++ b/baseline.pl
@@ -214,7 +214,7 @@ hint(ignore, [Other], Col, H)
 buggy(fratio, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
     X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
-    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 
@@ -264,7 +264,7 @@ buggy(fratio, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     maplist(append([Therapy]), [S | Subset], Interactions),
     % [Therapy:T0, Therapy:T0:Sex]
     maplist(atomics_to_string_sep(:), Interactions, Colon),
-    findall(invent(interactions, C), member(C, Colon), Invented),
+    findall(add(interactions, C), member(C, Colon), Invented),
     append(Invented, Int0, Int),
     Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 
@@ -402,7 +402,7 @@ hint(ignore, [Other], Col, H)
 buggy(pvalue, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
     X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
-    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 
@@ -447,7 +447,7 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     maplist(append([Therapy]), [S | Subset], Interactions),
     % [Therapy:T0, Therapy:T0:Sex]
     maplist(atomics_to_string_sep(:), Interactions, Colon),
-    findall(invent(interactions, C), member(C, Colon), Invented),
+    findall(add(interactions, C), member(C, Colon), Invented),
     append(Invented, Int0, Int),
     Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 
@@ -592,7 +592,7 @@ hint(ignore, [Other], Col, H)
 %buggy(cibase, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
 %    X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
 %    my_subset([S | Subset], Other, Difference),
-%    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+%    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
 %    append(Exclude0, Distractors, Exclude),
 %    Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 %
@@ -635,7 +635,7 @@ hint(noint, [_Int], _Col, H)
 %    maplist(append([Therapy]), [S | Subset], Interactions),
 %    % [Therapy:T0, Therapy:T0:Sex]
 %    maplist(atomics_to_string_sep(:), Interactions, Colon),
-%    findall(invent(interactions, C), member(C, Colon), Invented),
+%    findall(add(interactions, C), member(C, Colon), Invented),
 %    append(Invented, Int0, Int),
 %    Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 %

--- a/chisq.pl
+++ b/chisq.pl
@@ -243,7 +243,7 @@ hint(paren3, [From], Col, FB) =>
 % Appeared 3-5 times in the 2018 exams.
 buggy(chisq, stage(2), From, To, [step(buggy, flip, [])]) :-
     From = '<-'(z, zstat(P_VR, P_Box, P_pool, N_VR, N_Box)),
-    To = '<-'(z, invent_left(flip, 1/zstat(P_VR, P_Box, P_pool, N_VR, N_Box))).
+    To = '<-'(z, add_left(flip, 1/zstat(P_VR, P_Box, P_pool, N_VR, N_Box))).
 
 feedback(flip, [], Col, FB) =>
     FB = ["The result matches the reciprocal of the test statistic ", 

--- a/cigroups.pl
+++ b/cigroups.pl
@@ -46,7 +46,7 @@ render
             p(class('card-text'),
             [ "There are plans to introduce a new concept for teaching ",
               "mathematics nationwide. Prior to this, a school is testing ",
-              "whether the new concept improves the students' understanding ",
+              "whether the new concept improves the students\u0027 understanding ",
               "of the subject matter compared to the previous teaching concept. ", 
 	      "In this test phase, ", \mmlm([], N_MC = r(N_MC)),  " students from the model ",
               "class (MC) are taking part in lessons using the new concept and ",

--- a/cigroups.pl
+++ b/cigroups.pl
@@ -321,7 +321,7 @@ hint(sqrt2, [S2P, N_RC, N_MC], Col, FB)
 buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt3, [Ns])]) :-
     Ns = frac(1, _N_RC) + frac(1, _N_MC),
     X = dot(quant(RC, MC, S2P, N_RC, N_MC, Alpha), sqrt(dot(S2P, Ns))),
-    Y = dot(quant(RC, MC, S2P, N_RC, N_MC, Alpha), invent_right(sqrt3, sqrt(omit_right(sqrt3, dot(S2P, Ns))) * Ns)).
+    Y = dot(quant(RC, MC, S2P, N_RC, N_MC, Alpha), add_right(sqrt3, sqrt(omit_right(sqrt3, dot(S2P, Ns))) * Ns)).
 
 feedback(sqrt3, [Ns], Col, FB)
  => FB = [ "The result matches the confidence interval with the square root ",
@@ -341,7 +341,7 @@ hint(sqrt3, [_Ns], _Col, FB)
 buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt4, [Ns])]) :-
     Ns = frac(1, _N_RC) + frac(1, _N_MC),
     X = dfrac(RC - MC, sqrt(S2P * Ns)),
-    Y = dfrac(RC - MC, invent_right(sqrt4, sqrt(omit_right(sqrt4, dot(S2P, Ns))) * Ns)).
+    Y = dfrac(RC - MC, add_right(sqrt4, sqrt(omit_right(sqrt4, dot(S2P, Ns))) * Ns)).
 
 feedback(sqrt4, [Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 

--- a/cigroups.pl
+++ b/cigroups.pl
@@ -161,7 +161,7 @@ hint(tquant, [Alpha], Col, H)
 % Buggy-Rule: Use t-statistic instead of t-quantile
 buggy(cigroups, stage(2), X, Y, [step(buggy, tstat, [N_RC, N_MC, Alpha])]) :-
     X = quant(RC, MC, S2P, N_RC, N_MC, Alpha),
-    P = abbrev(t, dfrac(RC - MC, sqrt(S2P * (frac(1, N_RC) + frac(1, N_MC)))), ["the observed", space, t, "-statistic."]),
+    P = denote(t, dfrac(RC - MC, sqrt(S2P * (frac(1, N_RC) + frac(1, N_MC)))), ["the observed", space, t, "-statistic."]),
     Y = P. 
 
 feedback(tstat, [N_RC, N_MC, Alpha], Col, F)

--- a/depends.pl
+++ b/depends.pl
@@ -99,7 +99,7 @@ expert(drop_right(_, _)) :-
     !,
     fail.
 
-expert(invent_left(_, _)) :-
+expert(add_left(_, _)) :-
     !,
     fail.
 

--- a/depends.pl
+++ b/depends.pl
@@ -103,7 +103,7 @@ expert(add_left(_, _)) :-
     !,
     fail.
 
-expert(invent_right(_, _)) :-
+expert(add_right(_, _)) :-
     !,
     fail.
 

--- a/intermediate.pl
+++ b/intermediate.pl
@@ -51,7 +51,7 @@ complete(Topic, Task, add_left(_Bug, Expr)) :-
     !,
     complete(Topic, Task, Expr).
 
-complete(Topic, Task, invent_right(_Bug, Expr)) :-
+complete(Topic, Task, add_right(_Bug, Expr)) :-
     !,
     complete(Topic, Task, Expr).
 

--- a/intermediate.pl
+++ b/intermediate.pl
@@ -47,7 +47,7 @@ complete(Topic, Task, drop_right(_Bug, Expr)) :-
     complete(Topic, Task, L).
 
 % The invented parts need to be complete
-complete(Topic, Task, invent_left(_Bug, Expr)) :-
+complete(Topic, Task, add_left(_Bug, Expr)) :-
     !,
     complete(Topic, Task, Expr).
 

--- a/mathml.pl
+++ b/mathml.pl
@@ -1710,40 +1710,40 @@ prec(Flags, add_left(_, Expr), Prec),
     option(error(highlight), Flags, fix)
  => prec(Flags, Expr, Prec).
 
-math(Flags, invent_right(_Bug, Expr), New, M),
+math(Flags, add_right(_Bug, Expr), New, M),
     option(error(correct), Flags, fix)
  => Expr =.. [_Op, L, _R],
     Flags = New,
     M = L.
 
-math(Flags, invent_right(_Bug, Expr), New, M),
+math(Flags, add_right(_Bug, Expr), New, M),
     option(error(show), Flags, fix)
  => M = Expr,
     Flags = New.
 
-prec(Flags, invent_right(_, Expr), Prec),
+prec(Flags, add_right(_, Expr), Prec),
     option(error(show), Flags, fix)
  => prec(Flags, Expr, Prec).
 
-math(Flags, invent_right(_Bug, Expr), New, M),
+math(Flags, add_right(_Bug, Expr), New, M),
     option(error(fix), Flags, fix)
  => Expr =.. [_Op, L, _R],
     Flags = New,
     M = L.
 
-math(Flags, invent_right(Bug, L^R), New, M),
+math(Flags, add_right(Bug, L^R), New, M),
     option(error(highlight), Flags, fix)
  => Flags = New,
     M = L^color(Bug, R).
 
-math(Flags, invent_right(Bug, Expr), New, M),
+math(Flags, add_right(Bug, Expr), New, M),
     option(error(highlight), Flags, fix)
  => Expr =.. [Op, L, R],
     Expr1 =.. [Op, " ", R],
     Flags = New,
     M = list(space, [L, color(Bug, Expr1)]).
 
-prec(Flags, invent_right(_, Expr), Prec),
+prec(Flags, add_right(_, Expr), Prec),
     option(error(highlight), Flags, fix)
  => prec(Flags, Expr, Prec).
 
@@ -2139,7 +2139,7 @@ bugs_(add_left(Bug, Expr), List)
  => bugs_(Expr, Bugs),
     List = [Bug | Bugs].
 
-bugs_(invent_right(Bug, Expr), List)
+bugs_(add_right(Bug, Expr), List)
  => bugs_(Expr, Bugs),
     List = [Bug | Bugs].
 

--- a/mathml.pl
+++ b/mathml.pl
@@ -69,7 +69,7 @@ mmlm(A) -->
 %    html(ol(type(a), Items)).
 
 mmlm(Flags, A) -->
-    { member(abbrev(false), Flags),
+    { member(denote(false), Flags),
       mathml(Flags, A, M, _With)
     },
     html(M).
@@ -1039,24 +1039,24 @@ mathml :- mathml(-2 * -2).
 %
 % with s^2_pool denoting the pooled variance
 %
-ml(Flags, abbrev(A, _, _), X)
+ml(Flags, denote(A, _, _), X)
  => ml(Flags, A, X).
 
-paren(Flags, abbrev(A, _, _), Paren)
+paren(Flags, denote(A, _, _), Paren)
  => paren(Flags, A, Paren).
 
-prec(Flags, abbrev(A, _, _), Prec)
+prec(Flags, denote(A, _, _), Prec)
  => prec(Flags, A, Prec).
 
-type(Flags, abbrev(A, _, _), Type)
+type(Flags, denote(A, _, _), Type)
  => type(Flags, A, Type).
 
-denoting(Flags, abbrev(A, Expr, Info), Den)
+denoting(Flags, denote(A, Expr, Info), Den)
  => denoting(Flags, Expr, T),
     Den = [denoting(A, Expr, Info) | T].
 
 mathml :-
-    S2P = abbrev(sub(s, "pool")^2,
+    S2P = denote(sub(s, "pool")^2,
                    frac((sub('N', "A") - 1) * sub(s, "A")^2 +
                         (sub('N', "B") - 1) * sub(s, "B")^2,
                         sub('N', "A") + sub('N', "B") - 2),

--- a/mathml.pl
+++ b/mathml.pl
@@ -1208,8 +1208,8 @@ ml(Flags, cell(Cell), M)
 %
 omit(Flags, omit(_, _)) :-
     option(error(show), Flags, fix).
-%Kopie Invent
-invent(Flags, invent(_, _)) :-
+%Kopie add
+add(Flags, add(_, _)) :-
     option(error(fix), Flags, fix).
 
 math(Flags, [], New, M)
@@ -1226,7 +1226,7 @@ math(Flags, list(Sep, A), New, M)
     M = list1(Sep, Excluded).
 
 math(Flags, list(Sep, A), New, M)
- => exclude(invent(Flags), A, Excluded),
+ => exclude(add(Flags), A, Excluded),
     Flags = New,
     M = list1(Sep, Excluded).
 
@@ -1568,8 +1568,8 @@ math(Flags, omit(_Bug, Expr), New, M),
  => Flags = New,
     M = Expr.
 
-%Kopie Invent
-math(Flags, invent(_Bug, Expr), New, M),
+%Kopie add
+math(Flags, add(_Bug, Expr), New, M),
     option(error(correct), Flags, fix)
  => Flags = New,
     M = Expr.
@@ -1579,8 +1579,8 @@ math(Flags, omit(_Bug, _Expr), New, M),
  => Flags = New,
     M = "omitted".
 
-%Kopie Invent
-math(Flags, invent(_Bug, _Expr), New, M),
+%Kopie add
+math(Flags, add(_Bug, _Expr), New, M),
     option(error(show), Flags, fix)
  => Flags = New,
     M = "invented".
@@ -1591,7 +1591,7 @@ math(Flags, omit(Bug, Expr), New, M),
     M = color(Bug, box(color("#000000", Expr))).
 
 % Kopie!
-math(Flags, invent(Bug, Expr), New, M),
+math(Flags, add(Bug, Expr), New, M),
     option(error(highlight), Flags, fix)
  => Flags = New,
     M = color(Bug, box(color("#000000", Expr))).
@@ -1601,8 +1601,8 @@ math(Flags, omit(Bug, Expr), New, M),
  => Flags = New,
     M = color(Bug, cancel(color("#000000", Expr))).
 
-%Kopie Invent
-math(Flags, invent(Bug, Expr), New, M),
+%Kopie add
+math(Flags, add(Bug, Expr), New, M),
     option(error(fix), Flags, fix)
  => Flags = New,
     M = color(Bug, cancel(color("#000000", Expr))).
@@ -2120,8 +2120,8 @@ bugs_(omit(Bug, Expr), List)
  => bugs_(Expr, Bugs),
     List = [Bug | Bugs].
 
-%Kopie Invent
-bugs_(invent(Bug, Expr), List)
+%Kopie add
+bugs_(add(Bug, Expr), List)
  => bugs_(Expr, Bugs),
     List = [Bug | Bugs].
 

--- a/mathml.pl
+++ b/mathml.pl
@@ -1678,35 +1678,35 @@ math(Flags, instead(Bug, Wrong, Correct0, _Correct), New, M),
  => New = Flags,
     M = underbrace(list(space, ["instead of", correct(Correct0)]), color(Bug, show(Wrong))).
 
-math(Flags, invent_left(_Bug, Expr), New, M),
+math(Flags, add_left(_Bug, Expr), New, M),
     option(error(correct), Flags, fix)
  => Expr =.. [_Op, _L, R],
     Flags = New,
     M = R.
 
-math(Flags, invent_left(_Bug, Expr), New, M),
+math(Flags, add_left(_Bug, Expr), New, M),
     option(error(show), Flags, fix)
  => M = Expr,
     Flags = New.
 
-prec(Flags, invent_left(_, Expr), Prec),
+prec(Flags, add_left(_, Expr), Prec),
     option(error(show), Flags, fix)
  => prec(Flags, Expr, Prec).
 
-math(Flags, invent_left(_Bug, Expr), New, M),
+math(Flags, add_left(_Bug, Expr), New, M),
     option(error(fix), Flags, fix)
  => Expr =.. [_Op, _L, R],
     Flags = New,
     M = R.
 
-math(Flags, invent_left(Bug, Expr), New, M),
+math(Flags, add_left(Bug, Expr), New, M),
     option(error(highlight), Flags, fix)
  => Expr =.. [Op, L, R],
     Expr1 =.. [Op, L, " "],
     Flags = New,
     M = list(space, [color(Bug, Expr1), R]).
 
-prec(Flags, invent_left(_, Expr), Prec),
+prec(Flags, add_left(_, Expr), Prec),
     option(error(highlight), Flags, fix)
  => prec(Flags, Expr, Prec).
 
@@ -2135,7 +2135,7 @@ bugs_(drop_right(Bug, Expr), List)
     bugs_(L, Bugs),
     List = [Bug | Bugs].
 
-bugs_(invent_left(Bug, Expr), List)
+bugs_(add_left(Bug, Expr), List)
  => bugs_(Expr, Bugs),
     List = [Bug | Bugs].
 

--- a/powbinom.pl
+++ b/powbinom.pl
@@ -209,7 +209,7 @@ feedback(lower2, [], _Col, Feed)
 
 hint(lower2, [], _Col, Hint)
  => Hint = [ "The power is determined from the upper tail of the binomial ",
-             "distribution. Don't select the lower tail of the binomial distribution."
+             "distribution. Don\u0027t select the lower tail of the binomial distribution."
            ].
 
 % Buggy- Rule: Critical value based on density

--- a/r.R
+++ b/r.R
@@ -16,7 +16,7 @@ omit_right <- drop_right <- function(bug, expr)
   eval(substitute(expr)[[2]])
 }
 
-invent_left <- function(bug, expr)
+add_left <- function(bug, expr)
 {
   return(expr)
 }

--- a/r.R
+++ b/r.R
@@ -21,7 +21,7 @@ add_left <- function(bug, expr)
   return(expr)
 }
 
-invent_right <- function(bug, expr)
+add_right <- function(bug, expr)
 {
   return(expr)
 }

--- a/r.R
+++ b/r.R
@@ -31,7 +31,7 @@ instead <- function(bug, inst, of)
   return(inst)
 }
 
-abbrev <- function(s, expr, text)
+denote <- function(s, expr, text)
 {
   return(expr)
 }

--- a/steps.pl
+++ b/steps.pl
@@ -60,10 +60,10 @@ step(Type, Topic, Task, Stage, drop_right(Bug, Expr), Z, Flags) :-
     Y =.. [Op, New, R],
     Z = drop_right(Bug, Y).
 
-step(Type, Topic, Task, Stage, abbrev(Abbrev, Expr, Text), Z, Flags) :-
+step(Type, Topic, Task, Stage, denote(denote, Expr, Text), Z, Flags) :-
     !,
     step(Type, Topic, Task, Stage, Expr, New, Flags),
-    Z = abbrev(Abbrev, New, Text).
+    Z = denote(denote, New, Text).
 
 % Enter term and apply rule to components. For example, enter 
 % dfrac(Numerator, Denominator) and check if a rule can be applied to the

--- a/stuff/r.pl
+++ b/stuff/r.pl
@@ -800,7 +800,7 @@ pl_hook(skip(_, _, Expr), Res) :-
 pl_hook(denoting(_, Expr, _), Res) :-
     pl(Expr, Res).
 
-pl_hook(abbrev(_, Expr), Res) :-
+pl_hook(denote(_, Expr), Res) :-
     pl(Expr, Res).
 
 pl_hook(protect(Expr), Res) :-
@@ -1052,7 +1052,7 @@ r_init :-
             return(expr)
         }
 
-        abbrev <- function(sym, expr)
+        denote <- function(sym, expr)
         {
             return(expr)
         }

--- a/subgroups.pl
+++ b/subgroups.pl
@@ -218,7 +218,7 @@ hint(ignore, [Other], Col, H)
 buggy(fratio, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
     X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
-    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 
@@ -268,7 +268,7 @@ buggy(fratio, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     maplist(append([Therapy]), [S | Subset], Interactions),
     % [Therapy:T0, Therapy:T0:Sex]
     maplist(atomics_to_string_sep(:), Interactions, Colon),
-    findall(invent(interactions, C), member(C, Colon), Invented),
+    findall(add(interactions, C), member(C, Colon), Invented),
     append(Invented, Int0, Int),
     Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 
@@ -406,7 +406,7 @@ hint(ignore, [Other], Col, H)
 buggy(pvalue, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
     X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
-    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 
@@ -451,7 +451,7 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     maplist(append([Therapy]), [S | Subset], Interactions),
     % [Therapy:T0, Therapy:T0:Sex]
     maplist(atomics_to_string_sep(:), Interactions, Colon),
-    findall(invent(interactions, C), member(C, Colon), Invented),
+    findall(add(interactions, C), member(C, Colon), Invented),
     append(Invented, Int0, Int),
     Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 
@@ -596,7 +596,7 @@ hint(ignore, [Other], Col, H)
 %buggy(cibase, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
 %    X = baseline3(Prim, Cov, Strata, Other, Int, Exclude0, Therapy),
 %    my_subset([S | Subset], Other, Difference),
-%    findall(invent(distractors, D), member(D, [S | Subset]), Distractors),
+%    findall(add(distractors, D), member(D, [S | Subset]), Distractors),
 %    append(Exclude0, Distractors, Exclude),
 %    Y = baseline4(Prim, Cov, Strata, Difference, Int, Exclude, Therapy).
 %
@@ -639,7 +639,7 @@ hint(noint, [_Int], _Col, H)
 %    maplist(append([Therapy]), [S | Subset], Interactions),
 %    % [Therapy:T0, Therapy:T0:Sex]
 %    maplist(atomics_to_string_sep(:), Interactions, Colon),
-%    findall(invent(interactions, C), member(C, Colon), Invented),
+%    findall(add(interactions, C), member(C, Colon), Invented),
 %    append(Invented, Int0, Int),
 %    Y = baseline5(Prim, Cov, Strata, Other, Int, Exclude, Therapy).
 %

--- a/tasks.pl
+++ b/tasks.pl
@@ -42,7 +42,7 @@ interval:hook(@(Expr, Options), Res, Flags) :-
     MEps is -Eps,
     interval(Expr + MEps...Eps, Res, New).
 
-interval:hook(abbrev(_Sym, Expr, _Text), Flags, Expr, Flags).
+interval:hook(denote(_Sym, Expr, _Text), Flags, Expr, Flags).
 
 interval:hook(color(_Col, Expr), Flags, Expr, Flags).
 
@@ -165,7 +165,7 @@ feedback(Topic, Task, Data, _Form)
       findall(li(FB),
         ( member(step(buggy, Name, Args), Flags),
           memberchk(Name, Traps),
-          Topic:feedback(Name, Args, [topic(Topic), task(Task), abbrev(false) | Col], FB)
+          Topic:feedback(Name, Args, [topic(Topic), task(Task), denote(false) | Col], FB)
         ), Wrong0),
       ( Wrong0 = []
         -> Wrong = p(class('card-text'), "")
@@ -178,7 +178,7 @@ feedback(Topic, Task, Data, _Form)
       findall(li(FB),
         ( member(step(expert, Name, Args), Flags),
           \+ memberchk(Name, Hints),
-          Topic:feedback(Name, Args, [topic(Topic), task(Task), abbrev(false) | Col], FB)
+          Topic:feedback(Name, Args, [topic(Topic), task(Task), denote(false) | Col], FB)
         ), Praise0),
       ( Praise0 = []
         -> Praise = p(class('card-text'), "")
@@ -190,7 +190,7 @@ feedback(Topic, Task, Data, _Form)
       findall(li(FB),
         ( member(step(buggy, Name, Args), Flags),
           \+ memberchk(Name, Traps),
-          Topic:feedback(Name, Args, [topic(Topic), task(Task), abbrev(false) | Col], FB)
+          Topic:feedback(Name, Args, [topic(Topic), task(Task), denote(false) | Col], FB)
         ), Blame0),
       ( Blame0 = []
         -> Blame = p(class('card-text'), "")

--- a/tasks.pl
+++ b/tasks.pl
@@ -66,7 +66,7 @@ interval:hook(drop_left(_Bug, Expr), Flags, Right, Flags) :-
 
 interval:hook(add_left(_Bug, Expr), Flags, Expr, Flags).
 
-interval:hook(invent_right(_Bug, Expr), Flags, Expr, Flags).
+interval:hook(add_right(_Bug, Expr), Flags, Expr, Flags).
 
 interval:hook('<-'(Var, Expr), Res, Flags) :-
     interval(Expr, Res, Flags),

--- a/tasks.pl
+++ b/tasks.pl
@@ -64,7 +64,7 @@ interval:hook(drop_right(_Bug, Expr), Flags, Left, Flags) :-
 interval:hook(drop_left(_Bug, Expr), Flags, Right, Flags) :-
     Expr =.. [_Op, _Left, Right].
 
-interval:hook(invent_left(_Bug, Expr), Flags, Expr, Flags).
+interval:hook(add_left(_Bug, Expr), Flags, Expr, Flags).
 
 interval:hook(invent_right(_Bug, Expr), Flags, Expr, Flags).
 

--- a/tasks/relevant.pl
+++ b/tasks/relevant.pl
@@ -44,7 +44,7 @@ step(Rule, Code, denoting(Symbol, A, Label) >> To, Request) :-
     step(Rule, Code, A >> B, Request),
     To = denoting(Symbol, B, Label).
 
-step(Rule, Code, abbrev(_, A) >> To, Request) :-
+step(Rule, Code, denote(_, A) >> To, Request) :-
     !,
     step(Rule, Code, A >> B, Request),
     To = B.
@@ -164,7 +164,7 @@ consistent(denoting(_, Expr, _)) :-
     !,
     consistent(Expr).
 
-consistent(abbrev(_, _)) :-
+consistent(denote(_, _)) :-
     !.
 
 consistent(left_elsewhere(_, Expr)) :-
@@ -231,7 +231,7 @@ wrong(instead_of(_, _, _, _, _)).
 wrong(denoting(_, Expr, _)) :-
     wrong(Expr).
 
-wrong(abbrev(_, _)) :-
+wrong(denote(_, _)) :-
     fail.
 
 wrong(left_elsewhere(_, _)).

--- a/tasks/tpaired.pl
+++ b/tasks/tpaired.pl
@@ -31,7 +31,7 @@ r:pl_hook(alpha, r(alpha)).
 %
 :- multifile item/1.
 item(tpaired: paired_tratio(LU, [m_T0, m_EOT], s_D, [s_T0, s_EOT], 'N', mu)) :-
-    LU = abbrev(m_D, (m_T0 - m_EOT) ... m_D).
+    LU = denote(m_D, (m_T0 - m_EOT) ... m_D).
 
 :- multifile intermediate/1.
 intermediate(tpaired: paired_tratio/6).

--- a/tgroups.pl
+++ b/tgroups.pl
@@ -341,7 +341,7 @@ hint(sqrt1, [_], Col, FB)
 buggy(tratio, stage(2), From, To, [step(buggy, sqrt2, [Ns])]) :-
     Ns = frac(1, _N_VR) + frac(1, _N_Box),
     From = sqrt(S2P * Ns),
-    To = invent_right(sqrt2, sqrt(omit_right(sqrt2, S2P * Ns)) * Ns).
+    To = add_right(sqrt2, sqrt(omit_right(sqrt2, S2P * Ns)) * Ns).
 
 feedback(sqrt2, [Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 
@@ -584,7 +584,7 @@ hint(sqrt2, [S2P, N_VR, N_Box], Col, FB)
 buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt3, [Ns])]) :-
     Ns = frac(1, _N_VR) + frac(1, _N_Box),
     X = dot(quant(VR, Box, S2P, N_VR, N_Box, Alpha), sqrt(dot(S2P, Ns))),
-    Y = dot(quant(VR, Box, S2P, N_VR, N_Box, Alpha), invent_right(sqrt3, sqrt(omit_right(sqrt3, dot(S2P, Ns))) * Ns)).
+    Y = dot(quant(VR, Box, S2P, N_VR, N_Box, Alpha), add_right(sqrt3, sqrt(omit_right(sqrt3, dot(S2P, Ns))) * Ns)).
 
 feedback(sqrt3, [Ns], Col, FB)
  => FB = [ "The result matches the confidence interval with the square root ",
@@ -603,7 +603,7 @@ hint(sqrt3, [_Ns], _Col, FB)
 buggy(cigroups, stage(2), X, Y, [step(buggy, sqrt4, [Ns])]) :-
     Ns = frac(1, _N_VR) + frac(1, _N_Box),
     X = dfrac(VR - Box, sqrt(S2P * Ns)),
-    Y = dfrac(VR - Box, invent_right(sqrt4, sqrt(omit_right(sqrt4, dot(S2P, Ns))) * Ns)).
+    Y = dfrac(VR - Box, add_right(sqrt4, sqrt(omit_right(sqrt4, dot(S2P, Ns))) * Ns)).
 
 feedback(sqrt4, [Ns], Col, FB)
  => FB = [ "The result matches the expression for the ", 

--- a/tgroups.pl
+++ b/tgroups.pl
@@ -446,7 +446,7 @@ hint(tquant, [Alpha], Col, H)
 % Buggy-Rule: Use t-statistic instead of t-quantile
 buggy(cigroups, stage(2), X, Y, [step(buggy, tstat, [N_VR, N_Box, Alpha])]) :-
     X = quant(VR, Box, S2P, N_VR, N_Box, Alpha),
-    P = abbrev(t, dfrac(VR - Box, sqrt(S2P * (frac(1, N_VR) + frac(1, N_Box)))), ["the observed", space, t, "-statistic."]),
+    P = denote(t, dfrac(VR - Box, sqrt(S2P * (frac(1, N_VR) + frac(1, N_Box)))), ["the observed", space, t, "-statistic."]),
     Y = P. 
 
 feedback(tstat, [N_VR, N_Box, Alpha], Col, F)

--- a/tgroups.pl
+++ b/tgroups.pl
@@ -302,7 +302,7 @@ hint(school, [A, B], Col, FB)
 %% Buggy-Rule: Forgot paranthesis around numerator in t-statistic.
 %buggy(tratio, stage(2), From, To, [step(buggy, bug1, [VR, BOX, S2P, N_VR, N_BOX])]) :-
 %    From = tcalc(VR, BOX, S2P, N_VR, N_BOX),
-%    To = invent_left(bug1, VR - dfrac(BOX, sqrt(S2P * (1/N_VR + 1/N_BOX)))).
+%    To = add_left(bug1, VR - dfrac(BOX, sqrt(S2P * (1/N_VR + 1/N_BOX)))).
 %%VR - dfrac(BOX, sqrt(s2p * (1/N_VR + 1/N_BOX))).
 %
 %feedback(bug1, [_VR, _BOX, S2P, N_VR, N_BOX], Col, FB) =>

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -290,7 +290,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
     Y = add_left(bug1, 
-        D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
+        D - add_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
@@ -595,7 +595,7 @@ hint(qnorm, [_N, _Alpha], Col, H)
 % and forgetting to add Mu to the results of the bounds in the end.
 buggy(cipaired, stage(2), X, Y, [step(buggy, spss, [Mu]), excludes(qnorm), excludes(tstat), excludes(sqrt1)]) :-
     X = paired(D, Mu, S_D, N, Alpha),
-    Y = hdrs(pm(invent_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
+    Y = hdrs(pm(add_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
 
 feedback(spss, [Mu], Col, F)
  => F = [ "The result matches the upper and lower bound calculated by SPSS. ",

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -220,7 +220,7 @@ hint(indep, [], Col, F)
 expert(tratio, stage(2), X, Y, 
         [step(expert, tratio_indep, [T0, S_T0, N, EOT, S_EOT])]) :-
     X = indep(T0, S_T0, N, EOT, S_EOT, N),
-    P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+    P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     Y = tstat(dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))).
 
 feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
@@ -229,7 +229,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
         ].
 
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
- => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+ => P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
           "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."]) ].
 
@@ -556,7 +556,7 @@ hint(tquant, [_N, Alpha], Col, H)
 % Buggy-Rule: Use t-statistic instead of t-quantile
 buggy(cipaired, stage(2), X, Y, [step(buggy, tstat, [D, S_D, N, Mu, Alpha])]) :-
     X = quant(D, Mu, S_D, N, Alpha),
-    P = abbrev(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
+    P = denote(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
     Y = P. 
 
 feedback(tstat, [_D, _S_D, _N, _Mu, _Alpha], Col, F)

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -104,7 +104,7 @@ task(cipaired)
       session_data(resp(tpaired, cipaired, Resp), resp(tpaired, cipaired, '#.# to #.#'))
     },
     html(\htmlform([ "Determine the confidence interval for the change in ",
-        "the patients' HDRS scores." ], cipaired, Resp)).
+        "the patients\u0027 HDRS scores." ], cipaired, Resp)).
 
 %
 %% Expert rules for the t-ratio task

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -289,7 +289,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     X = dfrac(D - Mu, S / SQRT_N),
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
-    Y = invent_left(bug1, 
+    Y = add_left(bug1, 
         D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)

--- a/tpaired1t.pl
+++ b/tpaired1t.pl
@@ -104,7 +104,7 @@ task(cipaired)
       session_data(resp(tpaired, cipaired, Resp), resp(tpaired, cipaired, '#.# to #.#'))
     },
     html(\htmlform([ "Determine the confidence interval for the change in ",
-        "the students’ RANT scores." ], cipaired, Resp)).
+        "the students\u0027 RANT scores." ], cipaired, Resp)).
 
 
 

--- a/tpaired1t.pl
+++ b/tpaired1t.pl
@@ -288,7 +288,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
     Y = add_left(bug1, 
-        D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
+        D - add_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
@@ -634,7 +634,7 @@ hint(qnorm, [_N, _Alpha], Col, H)
 % and forgetting to add Mu to the results of the bounds in the end.
 buggy(cipaired, stage(2), X, Y, [step(buggy, spss, [Mu]), excludes(qnorm), excludes(tstat), excludes(sqrt1)]) :-
     X = paired(D, Mu, S_D, N, Alpha),
-    Y = hdrs(pm(invent_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
+    Y = hdrs(pm(add_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
 
 feedback(spss, [Mu], Col, F)
  => F = [ "The result matches the upper and lower bound calculated by SPSS. ",

--- a/tpaired1t.pl
+++ b/tpaired1t.pl
@@ -287,7 +287,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     X = dfrac(D - Mu, S / SQRT_N),
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
-    Y = invent_left(bug1, 
+    Y = add_left(bug1, 
         D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)

--- a/tpaired1t.pl
+++ b/tpaired1t.pl
@@ -217,7 +217,7 @@ hint(indep, [], Col, F)
 expert(tratio, stage(2), X, Y, 
         [step(expert, tratio_indep, [T0, S_T0, N, EOT, S_EOT])]) :-
     X = indep(T0, S_T0, N, EOT, S_EOT, N),
-    P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+    P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     Y = tstat(dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))).
 
 feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
@@ -226,7 +226,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
         ].
 
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
- => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+ => P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
           "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."])
         ].
@@ -595,7 +595,7 @@ hint(tquant, [_N, Alpha], Col, H)
 % Buggy-Rule: Use t-statistic instead of t-quantile
 buggy(cipaired, stage(2), X, Y, [step(buggy, tstat, [D, S_D, N, Mu, Alpha])]) :-
     X = quant(D, Mu, S_D, N, Alpha),
-    P = abbrev(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
+    P = denote(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
     Y = P. 
 
 feedback(tstat, [_D, _S_D, _N, _Mu, _Alpha], Col, F)

--- a/tpaired1tlow.pl
+++ b/tpaired1tlow.pl
@@ -293,7 +293,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
     Y = add_left(bug1, 
-        D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
+        D - add_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)
  => F = [ "The result matches the fraction without parentheses around the ", 
@@ -648,7 +648,7 @@ hint(qnorm, [_N, _Alpha], Col, H)
 % and forgetting to add Mu to the results of the bounds in the end.
 buggy(cipaired, stage(2), X, Y, [step(buggy, spss, [Mu]), excludes(qnorm), excludes(tstat), excludes(sqrt1)]) :-
     X = paired(D, Mu, S_D, N, Alpha),
-    Y = hdrs(pm(invent_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
+    Y = hdrs(pm(add_right(spss, D - Mu), dot(quant(D, Mu, S_D, N, Alpha), S_D / sqrt(N)))).
 
 feedback(spss, [Mu], Col, F)
  => F = [ "The result matches the upper and lower bound calculated by SPSS. ",

--- a/tpaired1tlow.pl
+++ b/tpaired1tlow.pl
@@ -292,7 +292,7 @@ buggy(tratio, stage(2), X, Y, [step(buggy, bug1, [D, Mu, S, SQRT_N])]) :-
     X = dfrac(D - Mu, S / SQRT_N),
     M0 = drop_left(bug1, D - Mu),
     S0 = drop_right(bug1, S / SQRT_N),
-    Y = invent_left(bug1, 
+    Y = add_left(bug1, 
         D - invent_right(bug1, dfrac(M0, S0) / SQRT_N)).
 
 feedback(bug1, [D, Mu, S, SQRT_N], Col, F)

--- a/tpaired1tlow.pl
+++ b/tpaired1tlow.pl
@@ -222,7 +222,7 @@ hint(indep, [], Col, F)
 expert(tratio, stage(2), X, Y, 
         [step(expert, tratio_indep, [T0, S_T0, N, EOT, S_EOT])]) :-
     X = indep(T0, S_T0, N, EOT, S_EOT, N),
-    P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+    P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     Y = tstat(dfrac(T0 - EOT, sqrt(P * (1/N + 1/N)))).
 
 feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
@@ -231,7 +231,7 @@ feedback(tratio_indep, [_T0, _S_T0, _N, _EOT, _S_EOT], Col, F)
         ].
 
 hint(tratio_indep, [T0, S_T0, N, EOT, S_EOT], Col, F)
- => P = abbrev(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
+ => P = denote(s2p, var_pool(S_T0^2, N, S_EOT^2, N), "the pooled variance"),
     F = [ "The ", \mmlm(Col, hyph(t, "ratio")), " for independent samples ",
           "would be ", \mmlm(Col, [dfrac(T0 - EOT, sqrt(P * (1/N + 1/N))), "."])
         ].
@@ -609,7 +609,7 @@ hint(tquant, [_N, Alpha], Col, H)
 % Buggy-Rule: Use t-statistic instead of t-quantile
 buggy(cipaired, stage(2), X, Y, [step(buggy, tstat, [D, S_D, N, Mu, Alpha])]) :-
     X = quant(D, Mu, S_D, N, Alpha),
-    P = abbrev(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
+    P = denote(t, dfrac(D - Mu, S_D / sqrt(N)), ["the observed", space, t, "-statistic."]),
     Y = P. 
 
 feedback(tstat, [_D, _S_D, _N, _Mu, _Alpha], Col, F)

--- a/tpaired1tlow.pl
+++ b/tpaired1tlow.pl
@@ -109,7 +109,7 @@ task(cipaired)
       session_data(resp(tpaired, cipaired, Resp), resp(tpaired, cipaired, '#.# to #.#'))
     },
     html(\htmlform([ "Determine the confidence interval for the change in ",
-        "the children's WRAT scores." ], cipaired, Resp)).
+        "the children\u0027s WRAT scores." ], cipaired, Resp)).
 
 
 

--- a/ztrans2.pl
+++ b/ztrans2.pl
@@ -103,7 +103,7 @@ hint(swap, [Mu, Sigma], Col, FB) =>
 % Buggy Rule (vardev swap) standard deviation was mistaken with variance.
 buggy(ztrans, stage(2), From, To, [step(buggy, vardev_swap, [sigma])]) :-
     From = Z * sigma + Mu,
-    To = Z * invent_right(vardev_swap, sigma^2) + Mu.
+    To = Z * add_right(vardev_swap, sigma^2) + Mu.
 
 feedback(vardev_swap, [Sigma], Col, FB) =>
     FB = [ "You squared ", \mmlm(Col, color(vardev_swap, Sigma)), " by mistake." ].


### PR DESCRIPTION
It is a big pull request with many lines changed, but I simply renamed some predicates across all files to match the names in R mathml.

- Renamed 'invent' to 'add'
- Renamed 'invent_left' to 'add_left'
- Renamed 'invent_right' to 'add_right'
- Renamed 'abbrev' to 'denote'

-Replaced the character ' with the respective ASCI code to fix misplaced syntax highlighting in IDE

