### PR TITLE
Renamed predicates sum/4 and subsup

### DIFF
--- a/mathml.pl
+++ b/mathml.pl
@@ -200,11 +200,12 @@ mathml :- mathml(sum(sub(x, i)) + sum(sub(y, i))).
 % Sum over index
 %
 % This function may be replaced in the future
-math(Flags, sum(I, From, To, A), New, M)
+math(Flags, sum_over(Arg, From, To), New, M)
  => Flags = New,
-    M = underover(sum(A), I=From, To).
+    M = underover(sum(Arg), From, To).
 
-mathml :- mathml(sum(i, 1, 10, sub(x, i))).
+mathml :-
+    mathml(sum_over('['(x, i), i=1, n)).
 
 %
 % Absolute value

--- a/mathml.pl
+++ b/mathml.pl
@@ -468,7 +468,7 @@ mathml :- mathml([](i, x)).
 %
 math(Flags, sub(A, Idx), New, X),
     type(Flags, A, sup(Bas, Pwr))
- => New = [replace(sup(Bas, Pwr), subsup(Bas, Idx, Pwr)) | Flags],
+ => New = [replace(sup(Bas, Pwr), subsupscript(Bas, Idx, Pwr)) | Flags],
     X = A.
 
 %
@@ -504,8 +504,8 @@ mathml :- mathml(sub(s^r, 'D')).
 % Check for sup(sub(A, Index), Power)
 %
 math(Flags, sup(A, Pwr), New, X),
-    type(Flags, A, sub(Bas, Idx))
- => New = [replace(sub(Bas, Idx), subsup(Bas, Idx, Pwr)) | Flags],
+    type(Flags, A, sub(Base, Idx))
+ => New = [replace(sub(Base, Idx), subsupscript(Base, Idx, Pwr)) | Flags],
     X = A.
 
 %
@@ -538,29 +538,29 @@ mathml :- mathml(sub(s^2, 'D')).
 %
 % Index and Exponent: s_D^2
 %
-math(Flags, subsup(A, Idx, Pwr), New, X),
-    prec(Flags, subsup(A, Idx, Pwr), Outer),
-    prec(Flags, A, Inner),
+math(Flags, subsupscript(Base, Idx, Pwr), New, X),
+    prec(Flags, subsupscript(Base, Idx, Pwr), Outer),
+    prec(Flags, Base, Inner),
     Outer < Inner
  => New = Flags,
-    X = subsup(paren(A), Idx, Pwr).
+    X = subsupscript(paren(Base), Idx, Pwr).
 
-ml(Flags, subsup(A, B, C), M)
- => ml(Flags, A, X),
-    ml(Flags, B, Y),
-    ml(Flags, C, Z),
+ml(Flags, subsupscript(Base, Idx, Pwr), M)
+ => ml(Flags, Base, X),
+    ml(Flags, Idx, Y),
+    ml(Flags, Pwr, Z),
     M = msubsup([X, Y, Z]).
 
-paren(Flags, subsup(A, _, _), Paren)
- => paren(Flags, A, Paren).
+paren(Flags, subsupscript(Base, _, _), Paren)
+ => paren(Flags, Base, Paren).
 
-prec(Flags, subsup(A, _, C), Prec)
- => prec(Flags, sup(A, C), Prec).
+prec(Flags, subsupscript(Base, _, Pwr), Prec)
+ => prec(Flags, sup(Base, Pwr), Prec).
 
-type(_Flags, subsup(A, B, C), Type)
- => Type = subsup(A, B, C).
+type(_Flags, subsupscript(Base, Idx, Pwr), Type)
+ => Type = subsupscript(Base, Idx, Pwr).
 
-mathml :- mathml(subsup(s, 'D', r)).
+mathml :- mathml(subsupscript(s, 'D', r)).
 
 %
 % Indices like s_D

--- a/tasks/tgroups.pl
+++ b/tasks/tgroups.pl
@@ -125,7 +125,7 @@ intermediate(tgroups: groups_t/6).
 % Expression for two-groups t-test
 expert(tgroups: groups_t, From >> To, Flags, Feed, Hint) :-
     From = groups_t(M_A, S_A, N_A, M_B, S_B, N_B),
-    Pool = denoting(subsup(s, "pool", 2), 
+    Pool = denoting(subsupscript(s, "pool", 2), 
                var_pool(square(S_A), N_A, square(S_B), N_B), 
                "the pooled variance"),
     To   = tratio(dfrac(dec(M_A - M_B, 2), dec(sqrt(Pool * dec(frac(1, N_A) + frac(1, N_B), 3)), 2)), N_A + N_B - 2),

--- a/tasks/tpaired.pl
+++ b/tasks/tpaired.pl
@@ -200,7 +200,7 @@ intermediate(tpaired: groups_t/6).
 % Expression for two-groups t-test
 expert(tpaired: groups_t, From >> To, Flags, Feed, Hint) :-
     From = groups_t(M_A, S_A, N_A, M_B, S_B, N_B),
-    Pool = denoting(subsup(s, "pool", 2), 
+    Pool = denoting(subsupscript(s, "pool", 2), 
                var_pool2(S_A^2, N_A, S_B^2, N_B), 
                "the pooled variance"),
     To   = tratio(dfrac(M_A - M_B, sqrt(Pool * (1/N_A + 1/N_B))), N_A + N_B - 2),


### PR DESCRIPTION
1. Renamed predicate sum/4 to sum_over/3 and modified order and names of arguments
There is still a difference to the mathml-version of 'sum_over'. Here 'subsupscript', whereas in mcclass 'underover' is used, leading to slightly different formatting. However, if 'subsupscript' is used in mcclass, the argument and summation sign is enclosed in brackets, instead of being placed after the summation sign with sub- and superscript.

2.  Renamed 'subsup' to 'subsupscript' and modified names of arguments.


<img width="256" alt="sum_over mcclass" src="https://github.com/mgondan/mcclass/assets/149394139/8561dc12-40af-45d0-ab9d-288306d0c019">

<img width="410" alt="sum_over R" src="https://github.com/mgondan/mcclass/assets/149394139/9e72c4db-f62a-4b35-a00f-8bdac0bab6ee">
