### PR TITLE
Changed precedence of ';'

### DIFF
--- a/mathml.pl
+++ b/mathml.pl
@@ -1997,8 +1997,8 @@ math(A / B, X)
     X = yfx(Prec, /, A, B).
 
 math((A ; B), X)
- => current_op(Prec, xfy, ;),
-    X = xfy(Prec, ;, A, B).
+ => current_op(Prec, xfx, =),
+    X = yfy(Prec, ;, A, B).
 
 math(A^B, X)
  => X = superscript(A, B).


### PR DESCRIPTION
Changed the precedence of ',' in order to avoid the parentheses in equations separated by ';' such as in the chisq task.