### PR TITLE
Rendering intervals and mutliple expressions in feedback

### DIFF
--- a/mathml.pl
+++ b/mathml.pl
@@ -2003,6 +2003,44 @@ math((A ; B), X)
 math(A^B, X)
  => X = superscript(A, B).
 
+% Legacy code
+% Intervals 
+% Rendering intervals as: '1 ... 2'
+%
+math(ci(L, U), X, Flags, New)
+=> New = Flags,
+   X = brackets(list(',', [L, U])).
+
+math('...'(L, U), X, Flags, New)
+=> New = Flags,
+   X = xfx(699, '...', floor(L), ceiling(U)).
+
+math(floor(A), X, Flags, New),
+   number(A),
+   A < 0
+=> select_option(digits(D), Flags, New0, 2),
+   New = [ceiling(D) | New0],
+   X = A.
+
+math(floor(A), X, Flags, New)
+=> select_option(digits(D), Flags, New0, 2),
+   New = [floor(D) | New0],
+   X = A.
+
+math(ceiling(A), X, Flags, New),
+   number(A),
+   A < 0
+=> select_option(digits(D), Flags, New0, 2),
+   New = [floor(D) | New0],
+   X = A.
+
+math(ceiling(A), X, Flags, New)
+=> select_option(digits(D), Flags, N, 2),
+   New = [ceiling(D) | N],
+   X = A.
+
+% End legacy code
+
 % Render operators with the appropriate parentheses
 ml(fy(Prec, Op, A), M, Flags)
  => ml(op(Op), S, Flags),

--- a/tasks.pl
+++ b/tasks.pl
@@ -30,6 +30,7 @@
 :- use_module(power).
 :- use_module(cigroups).
 :- use_module(subgroups).
+:- use_module(util).
 
 
 % Render R result
@@ -200,15 +201,17 @@ feedback(Topic, Task, Data, _Form)
                        [ "Other mistakes",
                          ul(class('card-text'), ul(Blame0))
                        ])
-      )
+      ),
+      util:expression_to_list(Expr, [topic(Topic), task(Task), error(fix) | Col], M1),
+      util:expression_to_list(Expr, [topic(Topic), task(Task), error(highlight) | Col], M2)
     },
     html(div(class(card),
       [ div(class('card-header text-white bg-warning'), "Careful"),
         div(class('card-body'),
           [ p(class('card-text'), "This is the correct expression:"),
-            p(class('card-text'), \mmlm([topic(Topic), task(Task), error(fix) | Col], Expr)),
+            p(class('card-text'), M1),
             p(class('card-text'), "Your response matches the following expression:"),
-            p(class('card-text'), \mmlm([topic(Topic), task(Task), error(highlight) | Col], Expr)),
+            p(class('card-text'), M2),
             Correct, Wrong, Praise, Blame
           ])
       ])).
@@ -265,7 +268,8 @@ pp_solution(Topic, Task, Expr-Result/Flags)
       findall(li(FB),
       ( member(step(expert, Name, Args), Flags),
         Topic:feedback(Name, Args, [topic(Topic), task(Task) | Col], FB)
-      ), Items)
+      ), Items),
+      util:expression_to_list(Expr, [topic(Topic), task(Task) | Col], M)
     },
     html(div(class('accordion-item'),
       [ h2(class('accordion-header'),
@@ -273,7 +277,7 @@ pp_solution(Topic, Task, Expr-Result/Flags)
             \mmlm([topic(Topic), task(Task) | Col], Result))),
         div(class('accordion-collapse collapse show'),
           div(class('accordion-body'), 
-           [ p(\mmlm([topic(Topic), task(Task) | Col], Expr)), 
+           [ p(M), 
              ul(Items)
            ]))
       ])).

--- a/util.pl
+++ b/util.pl
@@ -1,0 +1,30 @@
+:- module(util, [expression_to_list/3]).
+
+%
+% Used to render multiple expressions separated by semicolon as a list to be displayed as feedback.
+% If only one expression is found, it is not wrapped into a list.
+%
+%?- expression_to_list({1;2}, [color(zadd,"$blue")], M).
+%   M = ul([li([\mmlm([color(zadd, "$blue")], 1)]), li([\mmlm([color(zadd, "$blue")], 2)])]).
+%  
+%?- expression_to_list({1}, [color(zadd,"$blue")], M).
+%   M = \mmlm([color(zadd, "$blue")], 1) .  
+
+expression_to_list(Expr, Flags, M) :-
+    term_string(Expr, String),
+    string_concat('{', String1, String),
+    string_concat(String2, '}', String1),
+    atomic_list_concat(Parts, ';', String2),
+    as_list_items(Parts, Flags, M).
+ 
+as_list_items([Expr| []], Flags, M) :-
+    wrap_in_mmlm(Flags, Expr, M).
+
+as_list_items(Expr, Flags, ul(Items)) :-
+    maplist(wrap_in_mmlm(Flags), Expr, List),
+    maplist(list_item, List, Items).
+
+list_item(MmlmExpr, li([MmlmExpr])).
+
+wrap_in_mmlm(Flags, Expr, \mmlm(Flags, Term)) :-
+    term_string(Term, Expr).


### PR DESCRIPTION
I've added the code from mathml prior to the migration for displaying intervals in an "infix" notation.

Before:
<img width="415" alt="no_brackets" src="https://github.com/mgondan/mcclass/assets/149394139/9e6ce59a-9192-45f2-b538-6412ba35a69c">

<br/>

After:
<img width="372" alt="with_brackets" src="https://github.com/mgondan/mcclass/assets/149394139/930bddca-de5f-4c0b-bd41-c8a362e81e58">


Then, as you once suggested, I modified the rendering of the expressions in the feedback so that multiple expressions are no more displayed in a row separated by semicolons but rather as a list:

Before (the chi-square task):
<img width="785" alt="before2" src="https://github.com/mgondan/mcclass/assets/149394139/aaed998a-e8f7-41f6-8a7d-d258b639a9c7">

<img width="432" alt="before" src="https://github.com/mgondan/mcclass/assets/149394139/eb69ccfc-6ae0-443f-847f-284c3ecf5d96">

<br/>
<br/>

After:
<img width="551" alt="after2" src="https://github.com/mgondan/mcclass/assets/149394139/4bd3438d-3687-4fa8-abfc-1d9915d33683">

<img width="455" alt="after" src="https://github.com/mgondan/mcclass/assets/149394139/e0446f81-f634-4119-9137-545ee7f0b29d">


<br/>
<br/>

If there is only one expression, it is not wrapped in a list, as in the case of the tpaired task.
