### PR TITLE
Added hooks and predicates for rendering in tasks related to binomial distribution

### DIFF
--- a/dbinom.pl
+++ b/dbinom.pl
@@ -18,6 +18,7 @@ task(exactprob).
 math_hook(n, 'N').
 math_hook(p0, pi).
 
+rint:r_hook(p).
 rint:r_hook(n).
 rint:r_hook(k).
 rint:r_hook(p0).
@@ -49,14 +50,14 @@ start(item(k, n, p0)).
 
 % Recognise as a binomial density
 intermediate(exactprob, dbinom).
-expert(exactprob, stage(2), From, To, [step(expert, dens, [])]) :-
+expert(exactprob, stage(2), From, To, [step(expert, dbinom, [])]) :-
     From = item(K, N, P0),
-    To   = dbinom(K, N, P0).
+    To   = { '<-'(p, dbinom(K, N, P0)) }.
 
-feedback(dens, [], _Col, Feed) =>
+feedback(dbinom, [], _Col, Feed) =>
     Feed = [ "Correctly recognised the problem as a binomial probability." ].
 
-hint(dens, [], _Col, Hint) =>
+hint(dbinom, [], _Col, Hint) =>
     Hint = [ "This is a binomial probability." ].
 
 % Convert to product

--- a/mathml.pl
+++ b/mathml.pl
@@ -2980,6 +2980,25 @@ math(qbinom(Alpha, N, Pi), M)
  => M = fn(subscript(argmin, k),
           [fn(subscript('P', "Bi"), (['X' =< k] ; [N, Pi])) > Alpha]).
 
+% upper tail
+math(pwbinom(_K, N, Pi, Tail), X)
+=> X = fn(subscript('P', "Bi"), ([Tail] ; [N, Pi])).
+
+% upper critical value
+math(uqbinom(Alpha, N, Pi), X)
+=> X = fn(subscript("argmin", k), [fn(subscript('P', "Bi"), ([('X' >= k)] ; [N, Pi])) =< Alpha]).
+
+% lower critical value
+math(lqbinom(Alpha, N, Pi), X)
+=> X = fn(subscript("argmax", k), [fn(subscript('P', "Bi"), ([('X' =< k)] ; [N, Pi])) =< Alpha]).
+
+math(qbinom(Alpha, N, Pi), X)
+=> X = fn(subscript("argmax", k), [fn(subscript('P', "Bi"), ([('X' =< k)] ; [N, Pi])) =< Alpha]).
+
+% critical value
+math(cbinom(Alpha, N, Pi, Tail, Arg), X)
+=> X = fn(Arg, [fn(subscript('P', "Bi"), ([Tail] ; [N, Pi])) =< Alpha]).
+
 math(dpois(K, Rate), M)
   => M = fn(subscript('P', "Po"), (['X' = K] ; [Rate])).
 
@@ -3028,6 +3047,22 @@ math(pt(T, Df), M)
 
 math(qt(Alpha, Df), M)
  => M = fn(subscript('T', Alpha), [list(space, [Df, "df"])]).
+
+% Tails
+math(tail("upper", K), X)
+=> X = ('X' >= K).
+
+math(tail("lower", K), X)
+=> X = ('X' =< K).
+
+math(tail("equal", K), X)
+=> X = ('X' = K).
+
+math(arg("min", K), X)
+=> X = subscript(argmin, K).
+
+math(arg("max", K), X)
+=> X = subscript(argmax, K).
 
 % Functions like f(x) and f(x; a, b)
 ml(fn(Name, (Args ; Pars)), M, Flags)

--- a/powbinom.pl
+++ b/powbinom.pl
@@ -40,6 +40,8 @@ rint:r_hook(cbinom(_Alpha, _Size, _Prob, _Tail, _Arg)).
 rint:r_hook(pwbinom(_Crit, _Size, _Prob, _Tail)).
 rint:r_hook(pbinom(_Q, _Size, _Prob)).
 rint:r_hook(pbinom(_Q, _Size, _Prob, _Tail)).
+interval:hook(arg(A, _K), Res, Flags) :-
+  interval:int(A, Res, Flags).
 
 % Task description
 render

--- a/qbinom.pl
+++ b/qbinom.pl
@@ -23,7 +23,9 @@ rint:r_hook(k).
 rint:r_hook(uqbinom(_Alpha, _Size, _Prob)).
 rint:r_hook(lqbinom(_Alpha, _Size, _Prob)).
 rint:r_hook(tail(_Tail, _K)).
-rint:r_hook(arg(_Arg, _K)).
+interval:hook(arg(A, _K), Res, Flags) :-
+  interval:int(A, Res, Flags).
+%rint:r_hook(arg(_Arg, _K)).
 rint:r_hook(cbinom(_Alpha, _Size, _Prob, _Tail, _Arg)).
 rint:r_hook(pbinom(_Q, _Size, _Prob)).
 rint:r_hook(pbinom(_Q, _Size, _Prob, _Tail)).

--- a/qbinom.pl
+++ b/qbinom.pl
@@ -65,14 +65,14 @@ start(item(alpha, n, p0)).
 
 % This is a problem that involves the binomial test 
 intermediate(amountsuccess, binom).
-expert(amountsuccess, stage(2), From, To, [step(expert, problem, [])]) :-
+expert(amountsuccess, stage(2), From, To, [step(expert, binom, [])]) :-
     From = item(Alpha, N, P0),
-    To   = binom(Alpha, N, P0).
+    To   = { '<-'(k, binom(Alpha, N, P0)) }.
 
-feedback(problem, [], _Col, Feed) =>
+feedback(binom, [], _Col, Feed) =>
     Feed = [ "Correctly identified the problem as a binomial test." ].
 
-hint(problem, [], _Col, Hint) =>
+hint(binom, [], _Col, Hint) =>
     Hint = [ "This problem involves the binomial test." ].
 
 % Upper tail of the binomial distribution

--- a/rint.pl
+++ b/rint.pl
@@ -1,6 +1,6 @@
 :- module(rint, []).
 
-:- use_module(interval).
+:- reexport(interval). 
 :- use_module(r).
 :- use_module(session).
 

--- a/tasks.pl
+++ b/tasks.pl
@@ -217,16 +217,16 @@ feedback(Topic, Task, Data, _Form)
       ])).
 
 feedback(Topic, Task, _Data, Form) -->
-    { http_log("Form: ~w~n", [Form]),
-      % option(resp(R), Form),
-      session_data(resp(Topic, Task, R)),
-      quantity(N, Opt, R)
-    },
-    html(div(class(card),
-      [ div(class('card-header text-white bg-secondary'), "Feedback"),
-        div(class('card-body'),
-          p(class('card-text'), "Response: ~p ~p"-[N, Opt]))
-      ])).
+  { http_log("Form: ~w~n", [Form]),
+    % option(resp(R), Form),
+    session_data(resp(Topic, Task, R)),
+    quantity(N, _Opt, R)
+  },
+  html(div(class(card),
+    [ div(class('card-header text-white bg-warning'), "Careful"),
+      div(class('card-body'),
+        p(class('card-text'), "The response ~p is not correct and cannot be attributed to any known mistake."-[N]))
+    ])).
 
 feedback(Topic, Task, _Data, _Form) -->
     { % option(resp(R), Form),


### PR DESCRIPTION
**1) Added the hook to fix the error in the tasks 'powbinom' and 'qbinom'**

**2) Minor change to render the solutions in tasks 'dbinom' and 'qbinom'**

Before:
<img width="502" alt="solutions_dbinom_before" src="https://github.com/mgondan/mcclass/assets/149394139/2a7fc775-0877-4fe0-b5c1-28fca9f631f7">

<br>

After:
<img width="510" alt="solutions_dbinom_after" src="https://github.com/mgondan/mcclass/assets/149394139/6c5308e1-5408-4e90-8484-68b7bd7aa236">

<br>

**3) Added predicates from an older version to render the expressions in the task 'pwbinom'**

Before:
<img width="489" alt="before_powbinom" src="https://github.com/mgondan/mcclass/assets/149394139/f2e749a7-4839-4fcc-8716-219b7e1c9c85">

<br>

After:
<img width="455" alt="after_powbinom" src="https://github.com/mgondan/mcclass/assets/149394139/35bf4683-3ffc-436e-85de-b6c9cddb7c19">

<br>

**4) Changed the feedback given to a wrong response not derivable from the rules.**

Before:

<img width="557" alt="before_unknown_mistake" src="https://github.com/mgondan/mcclass/assets/149394139/643c1e96-2183-4d6e-b0f1-62d4443a5344">

<br>  
<br> 

After:
<img width="553" alt="after_unknown_mistake" src="https://github.com/mgondan/mcclass/assets/149394139/83628e5a-8a4b-4cb9-b869-73db3a30bacb">

<br>
<br>

Unfortunately, I've not been able yet to identify the issue with the duplicated mistake highlighting. It is interesting that it only occurs with 'k' and not with 'c' and only when the density function has been chosen ('tail = equal') and not when the lower tail has been used instead of the upper one.

<img width="539" alt="double_mistake" src="https://github.com/mgondan/mcclass/assets/149394139/d05be8bc-bbc7-4d9f-a205-539092987b8e">


