### PR TITLE
Added plot of binomial distribution

### DIFF
--- a/qbinom.R
+++ b/qbinom.R
@@ -44,3 +44,32 @@ tail = function(Tail, K)
 arg = function(Arg, K)
   return(Arg)
 
+library(ggplot2)
+library(svglite)
+
+rendered_probs <- 0.5
+  
+k_values <- 0:n
+
+probs <- pbinom(k_values, n, p0, lower.tail = FALSE)
+
+d <- data.frame(k = k_values, Probability = probs)
+
+d <- d[d$Probability < rendered_probs, ]
+
+plt <- ggplot(d, aes(x = k, y = Probability)) +
+  geom_bar(stat = "identity", fill = "lightblue") +
+  labs(title = paste("Cumulated Binomial Distribution (N =", n, ", p =", p0, ")"),
+       x = "Number of Successes",
+       y = "Cumulated Probability") +
+  scale_x_continuous(breaks = seq(0, n, by = 1)) + 
+  scale_y_continuous(breaks = seq(0, rendered_probs, by = 0.05)) +
+  geom_hline(yintercept = alpha, linetype = "dashed", color = "red") + 
+  theme(plot.background = element_rect(color = "black", size = 1))
+
+temp_file <- tempfile(fileext = ".svg")
+svglite(temp_file, width = 6, height = 4)
+print(plt)
+dev.off()
+svg <- paste(readLines(temp_file), collapse = "\n")
+unlink(temp_file)

--- a/qbinom.pl
+++ b/qbinom.pl
@@ -119,10 +119,12 @@ buggy(amountsuccess, stage(3), From, To, [step(buggy, dens, [K])]) :-
     To = instead(dens, tail("equal", K), tail("upper", K)).
 
 feedback(dens, [K], Col, Feed)
- => Feed = [ "The result matches the critical value based on the binomial ",
+ => r_topic(svg, Svg0),
+    format(atom(Svg), '<div style="display: flex; justify-content: center; margin-top: 1em">~w</div>', [Svg0]),
+    Feed = [ "The result matches the critical value based on the binomial ",
              "probability, ", \mmlm(Col, [fn(subscript('P', "Bi"), [color(dens, tail("equal", K))]), "."]),
              "Please report the critical value based on the cumulative ",
-             "distribution, ", \mmlm(Col, [fn(subscript('P', "Bi"), [tail("upper", K)]), "."])
+             "distribution, ", \mmlm(Col, [fn(subscript('P', "Bi"), [tail("upper", K)]), "."]), \[Svg]
            ].
 
 hint(dens, [_K], _Col, Hint)


### PR DESCRIPTION
First attempt of a graphical feedback.

The plot is generated via ggplot2 in R and then passed as a raw .svg-file to Prolog. 

For now, the plot is added to the feedback of a single buggy rule, but it should be possible to show it only once for the entire incorrect solution, even if it is the result of multiple buggy rules. 

<img width="598" alt="plot_binom" src="https://github.com/user-attachments/assets/3eb1458f-b8ce-4474-a0d9-9310783b0e79">
