### PR TITLE
Fix ztrans2.pl

### DIFF
--- a/search.pl
+++ b/search.pl
@@ -55,9 +55,9 @@ searchdep(Topic, Task, Expr_Res_Flags) :-
         dependencies(S),            % check dependencies here
         exclusive(S),
         codes(S, C),
-	interval_ex(E, R, [topic(Topic), task(Task)])
-%        interval(E, R, [topic(Topic), task(Task)]),
-%        interval(available(R), true)
+	      interval_ex(E, R, [topic(Topic), task(Task)]),
+%       interval(E, R, [topic(Topic), task(Task)]),
+        interval(available(R), true)
       ), Results),
     sort(2, @<, Results, Sorted),
     findall(E-R/F, member(res(E, R/_, F), Sorted), Expr_Res_Flags).
@@ -72,10 +72,8 @@ searchall(Topic, Task, Expr_Res_Flags) :-
     findall(E-R/F, member(res(E, R/_, F), Sorted), Expr_Res_Flags).
 
 interval_ex(E, R, Flags) :-
-    interval(E, R0, Flags),
-    interval(available(R0), true),
-    !,
-    R = R0.
+    interval(E, R, Flags),
+    !.
 
 interval_ex(E, _, _) :-
   throw(error(existence_error(interval, E), E)).

--- a/ztrans2.pl
+++ b/ztrans2.pl
@@ -19,6 +19,7 @@ r_hook(x).
 r_hook(sigma).
 r_hook(z).
 r_hook(p).
+r_hook(mu).
 
 render
 --> {start(item(_P, Mu, Sigma)) },


### PR DESCRIPTION
It would throw an exception: 

![grafik](https://github.com/user-attachments/assets/ca8bda71-8180-4e78-951e-72f724df1821)


although there is nothing wrong with the expression. Instead, it is interval(available(R0), true) that failed, because the result is 1.5NaN, but this is normal and should not be captured by the exception.

After:
![grafik](https://github.com/user-attachments/assets/6271d71d-3be4-4609-a333-5b69c3d20245)


