### PR TITLE
Avoid feedback for final expert step in mistake

### DIFF
--- a/feedback.pl
+++ b/feedback.pl
@@ -45,6 +45,7 @@ show_feedback(Topic, Task, Data)
       findall(li(F),
         ( member(step(expert, Name, Args), Flags),
           memberchk(Name, Hints),
+          \+ memberchk(finalstep, Args),
           Topic:feedback(Name, Args, [topic(Topic), task(Task) | Colors], F)
         ), Correct0),
       ( Correct0 = []

--- a/mistakes.pl
+++ b/mistakes.pl
@@ -36,6 +36,7 @@ init_mistakes1(Topic) :-
     colors(Expr, Colors),
     findall(li(F),
       ( member(step(_, Name, Args), Steps),
+        \+ memberchk(finalstep, Args),
         % memberchk(Name, Traps), % show only relevant feedback
         Topic:feedback(Name, Args, [topic(Topic), task(Task) | Colors], F)
       ), Feedback),

--- a/tpaired.pl
+++ b/tpaired.pl
@@ -142,11 +142,11 @@ hint(paired, Col, F)
 
 % Second step: Apply the formula for the t-ratio. dfrac/2 is a fraction in
 % "display" mode (a bit larger font than normal)
-expert(tratio, stage(1), X, Y, [step(expert, tratio, [D, Mu, S_D, N])]) :-
+expert(tratio, stage(1), X, Y, [step(expert, tratio, [D, Mu, S_D, N, finalstep])]) :-
     X = paired(D, Mu, S_D, N),
     Y = tstat(dfrac(D - Mu, S_D / sqrt(N))).
 
-feedback(tratio, [_D, _Mu, _S_D, _N], Col, F)
+feedback(tratio, [_D, _Mu, _S_D, _N, _], Col, F)
  => F = [ "Correctly identified ",
           "the ", \nowrap([\mmlm(Col, t), "-ratio"]), " ",
 	  "for paired samples." 
@@ -158,11 +158,11 @@ hint(tratio, Col, F)
         ].
 
 % Another correct result
-expert(tratio, stage(1), X, Y, [step(expert, abs_tratio, [D, Mu, S_D, N])]) :-
+expert(tratio, stage(1), X, Y, [step(expert, abs_tratio, [D, Mu, S_D, N, finalstep])]) :-
     X = paired(D, Mu, S_D, N),
     Y = tstat(abs(dfrac(D - Mu, S_D / sqrt(N)))).
 
-feedback(abs_tratio, [_D, _Mu, _S_D, _N], Col, F)
+feedback(abs_tratio, [_D, _Mu, _S_D, _N, _], Col, F)
  => F = [ "Correctly identified ",
           "the ", \nowrap([\mmlm(Col, t), "-ratio"]), " ",
 	  "for paired samples." 


### PR DESCRIPTION
### Before:
This feedback should not be given, because it is for the final expert step, which was actually not correct.

<img width="596" height="633" alt="grafik" src="https://github.com/user-attachments/assets/3bc8f3de-1c93-4c3a-8fda-1cef7cfd32bc" />



### After:
<img width="539" height="641" alt="grafik" src="https://github.com/user-attachments/assets/a7052cbc-f82e-4d76-af8f-2f469a4304c5" />



