### PR TITLE
Clean-up subgroups

### DIFF
--- a/subgroups.pl
+++ b/subgroups.pl
@@ -27,9 +27,28 @@ math_hook(m_T0, overline("T0")).
 math_hook(m_EOT, overline("EOT")).
 math_hook(s_T0, subscript(s, "T0")).
 math_hook(s_EOT, subscript(s, "EOT")).
-math_hook(ancova_f(Outcome, Cov, Strata, Other, Interaction, _Exclude, Therapy), M) :-
-    M = fn('ANOVA', ([lm(~(Outcome, Therapy + Cov + Strata + Other + Interaction))])).
-math_hook(f, 'F').
+
+math_hook(ancova_f(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy), M) :-
+      Row1 = '##'(subscript('H', 0) := lm(~(Outcome, Cov + Strata + Other + Interaction + Exclude))), 
+      Row2 = '##'(subscript('H', 1) := lm(~(Outcome, Therapy + Cov + Strata + Other + Interaction + Exclude))), 
+	    Row3 = '##'(fn('F', [subscript('H', 1) - subscript('H', 0)])),
+      M = table([Row1, Row2, Row3]).
+
+math_hook(ancova_p(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy), M) :-
+      Row1 = '##'(subscript('H', 0) := lm(~(Outcome, Cov + Strata + Other + Interaction + Exclude))), 
+      Row2 = '##'(subscript('H', 1) := lm(~(Outcome, Therapy + Cov + Strata + Other + Interaction + Exclude))), 
+	    Row3 = '##'(fn('F', [subscript('H', 1) - subscript('H', 0)])),
+	    Row4 = '##'(fn('pval', ['F'])),
+      M = table([Row1, Row2, Row3, Row4]).
+
+math_hook(ancova_ci(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy), M) :-
+      Row1 = '##'(subscript('H', 0) := lm(~(Outcome, Cov + Strata + Other + Interaction + Exclude))), 
+      Row2 = '##'(subscript('H', 1) := lm(~(Outcome, Therapy + Cov + Strata + Other + Interaction + Exclude))), 
+	    Row3 = '##'(fn('F', [subscript('H', 1) - subscript('H', 0)])),
+	    Row4 = '##'(fn('ci', ['F'])),
+      M = table([Row1, Row2, Row3, Row4]).
+
+math_hook(X := Y, list(:, [X, Y])).
 math_hook("age", "Age").
 math_hook("sex", "Sex").
 math_hook("therapy", "Therapy").
@@ -50,7 +69,7 @@ render(Flags)
               "in early childhood. The study is a randomized trial ",
               "on ", \mmlm(Flags, r('n')), " children, comparing Lidcombe ",
               "with treatment as usual (TAU). The significance level ",
-              "is set at", \mmlm(Flags, alpha = percent(0.05)), " two-tailed. ",
+              "is set at ", \mmlm(Flags, alpha = percent(0.05)), " two-tailed. ",
 	            "Analyze the impact of the biological sex of the children on the therapy effect."
             ]),
           div(class('container'),
@@ -66,38 +85,38 @@ render(Flags)
           p(class('card-text'),
              "Ficticious data can be downloaded below."),
 	  ul(
-            [ li("ID: Patient number"),
+            [ li("ID: patient number"),
               li("Sex: F, M (stratification factor)"),
-              li("Age: Age in months at inclusion"),
-              li("T0: Percentage of stuttered syllables at baseline"),
+              li("Age: age in months at inclusion"),
+              li("T0: percentage of stuttered syllables at baseline"),
               li("Therapy: Lidcombe, TAU"),
-              li(["Fidel: Treatment fidelity in percent, summarizing ",
+              li(["Fidel: treatment fidelity in percent, summarizing ",
                 "different indicators of adherence: ",
-                "0% (none)...100% (perfect)"]),
-              li(["EOT: Percentage of stuttered syllables 9 months after ",
+                "0\u0025 (none)...100\u0025 (perfect)"]),
+              li(["EOT: percentage of stuttered syllables 9 months after ",
                 "randomization (primary endpoint)"]),
-              li(["FU: Percentage of stuttered syllables 15 months after ",
+              li(["FU: percentage of stuttered syllables 15 months after ",
                 "randomization (secondary endpoint)"])]), 
           \download(baseline)
         ]))).
 
-% Question for F-Ratio
+% Question for F-Ratio task
 task(Flags, fratio)
 --> { start(item(_Outcome, _Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
       session_data(resp(baseline, fratio, Resp), resp(baseline, fratio, '#.##'))
     },
 	html(\htmlform([ "Does the Lidcombe therapy effect differ between boys and girls? ",
-	"Include the interaction term and report the respective ", \nowrap([\mmlm(Flags, 'F'), "-ratio."]) ], fratio, Resp)).
+	"Include the interaction term in the model and report the respective ", \nowrap([\mmlm(Flags, 'F'), "-ratio."]) ], fratio, Resp)).
 
-% Question for p-value
+% Question for p-value task
 task(Flags, pvalue)
 --> { start(item(_Outcome, _Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
       session_data(resp(baseline, pvalue, Resp), resp(baseline, pvalue, '.###'))
     },
-	html(\htmlform([ "Does the therapy effect differ between boys and girls? Include the interaction term and ", 
-	"report the ", \nowrap([\mmlm(Flags, p), "-value."]) ], pvalue, Resp)).
+	html(\htmlform([ "Does the therapy effect differ between boys and girls? Include the interaction term in the model and ", 
+	"report the respective ", \nowrap([\mmlm(Flags, p), "-value."]) ], pvalue, Resp)).
 
-% Question for CI
+% Question for CI task
 task(_Flags, cibase)
 --> { start(item(_Outcome, _Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
       session_data(resp(baseline, cibase, Resp), resp(baseline, cibase, '.###-.###'))
@@ -175,7 +194,7 @@ feedback(ignore, [Other], Col, F)
 
 hint(ignore, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
-    H = [ "Do not include the post-randomization ",
+    H = [ "Do not include any post-randomization ",
           "variables ", \mmlm(Col, list(+, Other)), " in the statistical model."
         ].
 
@@ -191,14 +210,14 @@ feedback(interaction, [_Interaction], _Col, F)
         ].
 
 hint(interaction, _Col, H)
- => H = [ "Do not forget the treatment-by-covariate interaction in the ",
+ => H = [ "Do not forget to include the treatment-by-covariate interaction in the ",
           "statistical model."
         ].
 
 % Step 6: Calculating the model
 expert(fratio, stage(2), X, Y, [step(expert, ancova, [Therapy])]) :-
     X = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
-    Y = { f <- ancova_f(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy) }.
+    Y = { ancova_f(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy) }.
 
 feedback(ancova, [Therapy], Col, F)
  => F = [ "The ", \nowrap([\mmlm(Col, 'F'), "-ratio"]), " for ", \mmlm(Col, Therapy), " has been reported."
@@ -206,12 +225,12 @@ feedback(ancova, [Therapy], Col, F)
 
 hint(ancova, Col, H)
  => start(item(_Outcome, _Cov, _Strata, _Other, _Interaction, _Exclude, Therapy)),
-    H = [ "Report the", \nowrap([\mmlm(Col, 'F'), "-ratio"]), " ",
+    H = [ "Report the ", \nowrap([\mmlm(Col, 'F'), "-ratio"]), " ",
           "for ", \mmlm(Col, [Therapy, "."])
         ].
 
 %
-% Buggy-Rules for the for the F-ratio task
+% Buggy-Rules for the F-ratio task
 %
 % Buggy-Rule: Omit relevant covariates (ex. forget to include baseline (T0))
 buggy(fratio, stage(2), X, Y, [step(buggy, covariates, [Cov, [R | Removed]])]) :-
@@ -222,8 +241,8 @@ buggy(fratio, stage(2), X, Y, [step(buggy, covariates, [Cov, [R | Removed]])]) :
     Y = baseline2(Outcome, Subset, Strata, Other, Interaction, Exclude, Therapy).
 
 feedback(covariates, [_Cov, Removed], Col, F)
- => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were forgotten ",
-          "in the model."
+ => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were erroneously excluded ",
+          "from the model."
         ].
 
 hint(covariates, Col, H)
@@ -241,14 +260,14 @@ buggy(fratio, stage(2), X, Y, [step(buggy, misstrata, [Strata, [R | Removed]])])
     Y = baseline3(Outcome, Cov, Subset, Other, Interaction, Exclude, Therapy).
 
 feedback(misstrata, [_Strata, Removed], Col, F)
- => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were excluded ",
-          "in the statistical model."].
-
+ => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were erroneously ",
+          " excluded from the statistical model."].
 
 hint(misstrata, Col, H)
  => start(item(_Outcome, _Cov, Strata, _Other, _Interaction, _Exclude, _Therapy)),
-    H = [ "The stratification variable(s) ", \mmlm(Col, list(+, Strata)), " should be included ",
-          "in the statistical model."
+    H = [ "Do not forget to include the stratification ",
+          "variable(s) ", \mmlm(Col, list(+, Strata)), " in the statistical ",
+          "model."
         ].
 
 % Buggy-Rule: add distractor variables to the model
@@ -266,8 +285,8 @@ feedback(distractors, [_Other, Dist], Col, F)
 
 hint(distractors, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
-    H = [ "Do not include the distractor variable(s) ", \mmlm(Col, list(+, Other)),
-          "in the statistical model."
+    H = [ "Do not include other outcomes ", \mmlm(Col, list(+, Other)), " as ",
+          "covariates in the statistical model."
         ].
 
 % Allow for treatment-by-covariate-interactions
@@ -287,20 +306,23 @@ buggy(fratio, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     % [[Therapy, T0], [Therapy, T0, Sex]]
     maplist(append([Therapy]), [S | Subset], Interactions),
     % [Therapy:T0, Therapy:T0:Sex]
-    maplist(atomics_to_string_sep(:), Interactions, Colon),
+    maplist(atomics_to_string_sep(:), Interactions, Colon0),
+    select("therapy:sex", Colon0, Colon),
+    dif(Colon, []),
     findall(add(interactions, C), member(C, Colon), Invented),
     append(Invented, Int0, Interaction),
     Y = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
 feedback(interactions, [Interaction], Col, F)
- => F = [ "The statistical model should not include the treatment-by-covariate ",
-          "interactions", \mmlm(Col, [list(+, Interaction), "."])
+ => F = [ "The following treatment-by-covariate interaction(s) were erroneously included in the model: ", 
+          \nowrap([\mmlm(Col, list(+, Interaction)), "."])
         ].
 
 hint(interactions, _Col, H)
  => H = [ "The statistical model should not include any ",
           "treatment-by-covariate interactions."
         ]. 
+
 %
 % Expert Rules for the p-value task
 %
@@ -309,30 +331,30 @@ intermediate(pvalue, item).
 % Step 1: Extract the correct information for an ANCOVA from the
 % task description
 intermediate(pvalue, baseline1).
-expert(pvalue, stage(1), X, Y, [step(expert, baseline, [])]) :-
+expert(pvalue, stage(1), X, Y, [step(expert, baseline1, [])]) :-
     X = item(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(baseline, [], _Col, F)
+feedback(baseline1, [], _Col, F)
  => F = [ "Correctly identified the problem as a group comparison with ",
           "covariate adjustment."
         ].
 
-hint(baseline, _Col, H)
+hint(baseline1, _Col, H)
  => H = "This is a group comparison with covariate adjustment.".
 
 % Step 2: Use the correct covariate(s)
 intermediate(pvalue, baseline2).
-expert(pvalue, stage(2), X, Y, [step(expert, covariates, [Cov])]) :-
+expert(pvalue, stage(2), X, Y, [step(expert, covariates1, [Cov])]) :-
     X = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(covariates, [Cov], Col, F)
+feedback(covariates1, [Cov], Col, F)
  => F = [ "The correct covariates ", \mmlm(Col, list(+, Cov)), " were included ",
           "in the model."
         ].
 
-hint(covariates, Col, H)
+hint(covariates1, Col, H)
  => start(item(_Outcome, Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The covariate(s) ", \mmlm(Col, list(+, Cov)), " should be included ",
           "in the statistical model."
@@ -340,128 +362,129 @@ hint(covariates, Col, H)
 
 % Step 3: Use the correct stratification variable(s)
 intermediate(pvalue, baseline3).
-expert(pvalue, stage(2), X, Y, [step(expert, stratification, [Strata])]) :-
+expert(pvalue, stage(2), X, Y, [step(expert, stratification1, [Strata])]) :-
     X = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(stratification, [Strata], Col, F)
+feedback(stratification1, [Strata], Col, F)
  => F = [ "The correct strata ", \mmlm(Col, list(+, Strata)), " were included ",
           "in the model."
         ].
 
-hint(stratification, Col, H)
+hint(stratification1, Col, H)
  => start(item(_Outcome, _Cov, Strata, _Other, _Interaction, _Exclude, _Therapy)),
-    H = [ "The strata ", \mmlm(Col, list(+, Strata)), " should be included ",
-          "in the statistical model."
+    H = [ "Do not forget to include the stratification ",
+          "variable(s) ", \mmlm(Col, list(+, Strata)), " in the statistical ",
+          "model."
         ].
 
 % Step 4: Ignore distractors
 intermediate(pvalue, baseline4).
-expert(pvalue, stage(2), X, Y, [step(expert, ignore, [Other])]) :-
+expert(pvalue, stage(2), X, Y, [step(expert, ignore1, [Other])]) :-
     X = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline4(Outcome, Cov, Strata, [], Interaction, Exclude, Therapy).
 
-feedback(ignore, [Other], Col, F)
+feedback(ignore1, [Other], Col, F)
  => F = [ "The post-randomization variable(s) ", \mmlm(Col, list(+, Other)), " were ",
           "correctly excluded from the statistical model."
         ].
 
-hint(ignore, Col, H)
+hint(ignore1, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
     H = [ "Do not include the post-randomization ",
           "variables ", \mmlm(Col, list(+, Other)), " in the statistical model."
         ].
 
-% Step 5: Add treatment-by-covariate interaction
+% Step 5: No treatment-by-covariate interactions
 intermediate(pvalue, baseline5).
-expert(pvalue, stage(2), X, Y, [step(expert, interaction, [Interaction])]) :-
+expert(pvalue, stage(2), X, Y, [step(expert, interaction1, [Interaction])]) :-
     X = baseline4(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(interaction, [_Interaction], _Col, F)
+feedback(interaction1, [_Interaction], _Col, F)
  => F = [ "Correctly included the treatment-by-covariate interaction in ",
           "the analysis."
         ].
 
-hint(interaction, _Col, H)
+hint(interaction1, _Col, H)
  => H = [ "Do not forget the treatment-by-covariate interaction in the ",
           "statistical model."
         ].
 
 % Step 6: Calculating the model
-expert(pvalue, stage(2), X, Y, [step(expert, ancova, [])]) :-
+expert(pvalue, stage(2), X, Y, [step(expert, ancova1, [])]) :-
     X = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
-    Y = { p <- ancova_p(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy) }.
+    Y = ancova_p(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(ancova, [], Col, F)
+feedback(ancova1, [], Col, F)
  => F = [ "The ", \nowrap([\mmlm(Col, p), "-value"]), " for the ", \nowrap([\mmlm(Col, 'F'), "-ratio"]), " has been reported."
         ].
 
-hint(ancova, Col, H)
+hint(ancova1, Col, H)
  => H = [ "Report the", \nowrap([\mmlm(Col, p), "-value"]), " for the", \nowrap([\mmlm(Col, 'F'), "-ratio"])
         ].
 
 % Buggy-Rules for the for the p-value task
 %
 % Buggy-Rule: Omit relevant covariates (ex. forget to include baseline (T0))
-buggy(pvalue, stage(2), X, Y, [step(buggy, covariates, [Cov, [R | Removed]])]) :-
+buggy(pvalue, stage(2), X, Y, [step(buggy, covariates1, [Cov, [R | Removed]])]) :-
     X = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset(Subset, Cov, [R | Removed]),
     findall(omit(covariates , O), member(O, [R | Removed]), Omitted),
     append(Exclude0, Omitted, Exclude),
     Y = baseline2(Outcome, Subset, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(covariates, [_Cov, Removed], Col, F)
- => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were forgotten ",
-          "in the model."
+feedback(covariates1, [_Cov, Removed], Col, F)
+ => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were erroneously excluded ",
+          "from the model."
         ].
 
-hint(covariates, Col, H)
+hint(covariates1, Col, H)
  => start(item(_Outcome, Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The covariate(s) ", \mmlm(Col, list(+, Cov)), " should be included ",
           "in the statistical model."
         ].
 
 % Buggy-Rule: Exclude Strata variable(s)
-buggy(pvalue, stage(2), X, Y, [step(buggy, misstrata, [Strata, [R | Removed]])]) :-
+buggy(pvalue, stage(2), X, Y, [step(buggy, misstrata1, [Strata, [R | Removed]])]) :-
     X = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset(Subset, Strata, [R | Removed]),
     findall(omit(misstrata, O), member(O, [R | Removed]), Omitted),
     append(Exclude0, Omitted, Exclude),
     Y = baseline3(Outcome, Cov, Subset, Other, Interaction, Exclude, Therapy).
 
-feedback(misstrata, [_Strata, Removed], Col, F)
- => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were excluded ",
-          "in the statistical model."].
+feedback(misstrata1, [_Strata, Removed], Col, F)
+ => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were erroneously ",
+          " excluded from the statistical model."].
 
 
-hint(misstrata, Col, H)
+hint(misstrata1, Col, H)
  => start(item(_Outcome, _Cov, Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The stratification variable(s) ", \mmlm(Col, list(+, Strata)), " should be included ",
           "in the statistical model."
         ].
 
 % Buggy-Rule: add distractor variables to the model
-buggy(pvalue, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
+buggy(pvalue, stage(2), X, Y, [step(buggy, distractors1, [Other, [S | Subset]])]) :-
     X = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
     findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Outcome, Cov, Strata, Difference, Interaction, Exclude, Therapy).
 
-feedback(distractors, [_Other, Dist], Col, F)
+feedback(distractors1, [_Other, Dist], Col, F)
  => F = [ "The distractor variable(s) ", \mmlm(Col, list(+, Dist)), " were erroneously ",
           "included in the model."
         ].
 
-hint(distractors, Col, H)
+hint(distractors1, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
     H = [ "Do not include the distractor variable(s) ", \mmlm(Col, list(+, Other)),
           "in the statistical model."
         ].
 
 % Buggy-Rule
-buggy(pvalue, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
+buggy(pvalue, stage(2), X, Y, [step(buggy, interactions1, [Colon])]) :-
     X = baseline4(Outcome, Cov, Strata, Other, Int0, Exclude, Therapy),
     % T0, Sex
     append(Strata, Cov, Covariates),
@@ -478,12 +501,12 @@ buggy(pvalue, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     append(Invented, Int0, Interaction),
     Y = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(interactions, [Interaction], Col, F)
- => F = [ "The statistical model should not include the treatment-by-covariate ",
-          "interactions", \mmlm(Col, [list(+, Interaction), "."])
+feedback(interactions1, [Interaction], Col, F)
+ => F = [ "The following treatment-by-covariate interaction(s) were erroneously included in the model: ", 
+          \nowrap([\mmlm(Col, list(+, Interaction)), "."])
         ].
 
-hint(interactions, _Col, H)
+hint(interactions1, _Col, H)
  => H = [ "The statistical model should not include any ",
           "treatment-by-covariate interactions."
         ]. 
@@ -497,30 +520,30 @@ intermediate(cibase, item).
 % Step 1: Extract the correct information for an ANCOVA from the
 % task description
 intermediate(cibase, baseline1).
-expert(cibase, stage(1), X, Y, [step(expert, baseline, [])]) :-
+expert(cibase, stage(1), X, Y, [step(expert, baseline2, [])]) :-
     X = item(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(baseline, [], _Col, F)
+feedback(baseline2, [], _Col, F)
  => F = [ "Correctly identified the problem as a group comparison with ",
           "covariate adjustment."
         ].
 
-hint(baseline, _Col, H)
+hint(baseline2, _Col, H)
  => H = "This is a group comparison with covariate adjustment.".
 
 % Step 2: Use the correct covariate(s)
 intermediate(cibase, baseline2).
-expert(cibase, stage(2), X, Y, [step(expert, covariates, [Cov])]) :-
+expert(cibase, stage(2), X, Y, [step(expert, covariates2, [Cov])]) :-
     X = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(covariates, [Cov], Col, F)
+feedback(covariates2, [Cov], Col, F)
  => F = [ "The correct covariates ", \mmlm(Col, list(+, Cov)), " were included ",
           "in the model."
         ].
 
-hint(covariates, Col, H)
+hint(covariates2, Col, H)
  => start(item(_Outcome, Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The covariate(s) ", \mmlm(Col, list(+, Cov)), " should be included ",
           "in the statistical model."
@@ -528,16 +551,16 @@ hint(covariates, Col, H)
 
 % Step 3: Use the correct stratification variable(s)
 intermediate(cibase, baseline3).
-expert(cibase, stage(2), X, Y, [step(expert, stratification, [Strata])]) :-
+expert(cibase, stage(2), X, Y, [step(expert, stratification2, [Strata])]) :-
     X = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(stratification, [Strata], Col, F)
+feedback(stratification2, [Strata], Col, F)
  => F = [ "The correct strata ", \mmlm(Col, list(+, Strata)), " were included ",
           "in the model."
         ].
 
-hint(stratification, Col, H)
+hint(stratification2, Col, H)
  => start(item(_Outcome, _Cov, Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The strata ", \mmlm(Col, list(+, Strata)), " should be included ",
           "in the statistical model."
@@ -545,16 +568,16 @@ hint(stratification, Col, H)
 
 % Step 4: Ignore distractors
 intermediate(cibase, baseline4).
-expert(cibase, stage(2), X, Y, [step(expert, ignore, [Other])]) :-
+expert(cibase, stage(2), X, Y, [step(expert, ignore2, [Other])]) :-
     X = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline4(Outcome, Cov, Strata, [], Interaction, Exclude, Therapy).
 
-feedback(ignore, [Other], Col, F)
+feedback(ignore2, [Other], Col, F)
  => F = [ "The post-randomization variable(s) ", \mmlm(Col, list(+, Other)), " were ",
           "correctly excluded from the statistical model."
         ].
 
-hint(ignore, Col, H)
+hint(ignore2, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
     H = [ "Do not include the post-randomization ",
           "variables ", \mmlm(Col, list(+, Other)), " in the statistical model."
@@ -562,94 +585,94 @@ hint(ignore, Col, H)
 
 % Step 5: Add treatment-by-covariate interaction
 intermediate(cibase, baseline5).
-expert(cibase, stage(2), X, Y, [step(expert, interaction, [Interaction])]) :-
+expert(cibase, stage(2), X, Y, [step(expert, interaction2, [Interaction])]) :-
     X = baseline4(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(interaction, [_Interaction], _Col, F)
+feedback(interaction2, [_Interaction], _Col, F)
  => F = [ "Correctly included the treatment-by-covariate interaction in ",
           "the analysis."
         ].
 
-hint(interaction, _Col, H)
- => H = [ "Do not forget the treatment-by-covariate interaction in the ",
+hint(interaction2, _Col, H)
+ => H = [ "Do not forget to include the treatment-by-covariate interaction in the ",
           "statistical model."
         ].
 
 % Step 6: Calculating the model
-expert(cibase, stage(2), X, Y, [step(expert, ancova, [])]) :-
+expert(cibase, stage(2), X, Y, [step(expert, ancova2, [])]) :-
     X = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy),
     Y = { ancova_ci(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy) }.
 
-feedback(ancova, [], _Col, F)
- => F = [ "The confidence intervals for the group contrast have been reported."
+feedback(ancova2, [], _Col, F)
+ => F = [ "The confidence interval for the group contrast has been reported."
         ].
 
-hint(ancova, _Col, H)
- => H = [ "Report the confidence intervals for the group constrast."
+hint(ancova2, _Col, H)
+ => H = [ "Report the confidence intervals for the group contrast."
         ].
 
 % Buggy-Rules for the for the confidence interval task
 %
 % Buggy-Rule: Omit relevant covariates (ex. forget to include baseline (T0))
-buggy(cibase, stage(2), X, Y, [step(buggy, covariates, [Cov, [R | Removed]])]) :-
+buggy(cibase, stage(2), X, Y, [step(buggy, covariates2, [Cov, [R | Removed]])]) :-
     X = baseline1(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset(Subset, Cov, [R | Removed]),
     findall(omit(covariates , O), member(O, [R | Removed]), Omitted),
     append(Exclude0, Omitted, Exclude),
     Y = baseline2(Outcome, Subset, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(covariates, [_Cov, Removed], Col, F)
- => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were forgotten ",
-          "in the model."
+feedback(covariates2, [_Cov, Removed], Col, F)
+ => F = [ "The covariates ", \mmlm(Col, list(+, Removed)), " were erroneously excluded ",
+          "from the model."
         ].
 
-hint(covariates, Col, H)
+hint(covariates2, Col, H)
  => start(item(_Outcome, Cov, _Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The covariate(s) ", \mmlm(Col, list(+, Cov)), " should be included ",
           "in the statistical model."
         ].
 
 % Buggy-Rule: Exclude Strata variable(s)
-buggy(cibase, stage(2), X, Y, [step(buggy, misstrata, [Strata, [R | Removed]])]) :-
+buggy(cibase, stage(2), X, Y, [step(buggy, misstrata2, [Strata, [R | Removed]])]) :-
     X = baseline2(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset(Subset, Strata, [R | Removed]),
     findall(omit(misstrata, O), member(O, [R | Removed]), Omitted),
     append(Exclude0, Omitted, Exclude),
     Y = baseline3(Outcome, Cov, Subset, Other, Interaction, Exclude, Therapy).
 
-feedback(misstrata, [_Strata, Removed], Col, F)
- => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were excluded ",
-          "in the statistical model."].
+feedback(misstrata2, [_Strata, Removed], Col, F)
+ => F = [ "The relevant stratification variable(s) ", \mmlm(Col, list(+, Removed)), " were erroneously ",
+          " excluded from the statistical model."].
 
 
-hint(misstrata, Col, H)
+hint(misstrata2, Col, H)
  => start(item(_Outcome, _Cov, Strata, _Other, _Interaction, _Exclude, _Therapy)),
     H = [ "The stratification variable(s) ", \mmlm(Col, list(+, Strata)), " should be included ",
           "in the statistical model."
         ].
 
 % Buggy-Rule: add distractor variables to the model
-buggy(cibase, stage(2), X, Y, [step(buggy, distractors, [Other, [S | Subset]])]) :-
+buggy(cibase, stage(2), X, Y, [step(buggy, distractors2, [Other, [S | Subset]])]) :-
     X = baseline3(Outcome, Cov, Strata, Other, Interaction, Exclude0, Therapy),
     my_subset([S | Subset], Other, Difference),
     findall(add(distractors, D), member(D, [S | Subset]), Distractors),
     append(Exclude0, Distractors, Exclude),
     Y = baseline4(Outcome, Cov, Strata, Difference, Interaction, Exclude, Therapy).
 
-feedback(distractors, [_Other, Dist], Col, F)
+feedback(distractors2, [_Other, Dist], Col, F)
  => F = [ "The distractor variable(s) ", \mmlm(Col, list(+, Dist)), " were erroneously ",
           "included in the model."
         ].
 
-hint(distractors, Col, H)
+hint(distractors2, Col, H)
  => start(item(_Outcome, _Cov, _Strata, Other, _Interaction, _Exclude, _Therapy)),
     H = [ "Do not include the distractor variable(s) ", \mmlm(Col, list(+, Other)),
           "in the statistical model."
         ].
 
 % Buggy-Rule
-buggy(cibase, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
+buggy(cibase, stage(2), X, Y, [step(buggy, interactions2, [Colon])]) :-
     X = baseline4(Outcome, Cov, Strata, Other, Int0, Exclude, Therapy),
     % T0, Sex
     append(Strata, Cov, Covariates),
@@ -666,12 +689,12 @@ buggy(cibase, stage(2), X, Y, [step(buggy, interactions, [Colon])]) :-
     append(Invented, Int0, Interaction),
     Y = baseline5(Outcome, Cov, Strata, Other, Interaction, Exclude, Therapy).
 
-feedback(interactions, [Interaction], Col, F)
- => F = [ "The statistical model should not include the treatment-by-covariate ",
-          "interactions", \mmlm(Col, [list(+, Interaction), "."])
+feedback(interactions2, [Interaction], Col, F)
+ => F = [ "The following treatment-by-covariate interaction(s) were erroneously included in the model: ", 
+          \nowrap([\mmlm(Col, list(+, Interaction)), "."])
         ].
 
-hint(interactions, _Col, H)
+hint(interactions2, _Col, H)
  => H = [ "The statistical model should not include any ",
           "treatment-by-covariate interactions."
         ]. 


### PR DESCRIPTION
### Before:
<img width="996" height="308" alt="grafik" src="https://github.com/user-attachments/assets/d7882a7d-63eb-486e-905f-864fa6f640ed" />

### After (same as baseline topic):
<img width="720" height="278" alt="grafik" src="https://github.com/user-attachments/assets/f120706c-7b3a-41ee-a486-06d4953f0277" />



### Before:
<img width="766" height="203" alt="grafik" src="https://github.com/user-attachments/assets/6121e795-036a-41aa-bbec-d5982dd2a210" />

### After:
Excluded therapy:sex from buggy rule because it is equivalent to sex:therapy, which is required by the task.