### PR TITLE
Bug wrong numerical solutions

### DIFF
--- a/r_session.pl
+++ b/r_session.pl
@@ -1,5 +1,5 @@
 :-  module(r_session, 
-      [ r//1, r_topic_source/0, r_topic/1, r_topic/2, r_topic//1 ]).
+      [ r//1, r_topic_source/0, r_topic/1, r_topic/2, r_topic//1, r_topic_source_with_check/0]).
 
 :-  reexport(library(r)).
 :-  use_module(session).
@@ -47,3 +47,15 @@ r_topic :-
     ;   r(with(Topic, '<-'(Variant, 'new.env'()))),
         assert(variant(Topic, Variant))
     ),  !.
+
+% Load .R topic file only once per variant (not multiple times for each task) 
+r_topic_source_with_check :-
+    b_getval(topic, Topic),
+    topic(Topic),
+    b_getval(variant, Variant),
+    variant(Topic, Variant),
+    !.
+
+r_topic_source_with_check :-
+    r_topic_source.
+

--- a/tasks.pl
+++ b/tasks.pl
@@ -59,7 +59,7 @@ init_variant(Topic, Task) :-
     length(Variants, N),
     format(atom(Variant), "var~w", N),
     b_setval(variant, Variant),
-    r_topic_source,
+    r_topic_source_with_check,
     solutions(Topic, Task, S),
     mistakes(Topic, Task, M),
     assert(taskdata(Topic, Task, Variant, [solutions(S), mistakes(M)])).
@@ -101,8 +101,6 @@ done_topics :-
 % Render R result
 mathml:math_hook(r(Expr), Res) :-
     r_topic(Expr, Res).
-
-:- dynamic taskdata/4.
 
 % more to come
 task(Topic, Task, Data) :-


### PR DESCRIPTION
# Before

<img width="1652" height="782" alt="grafik" src="https://github.com/user-attachments/assets/27b0ea9e-c5f4-4235-a5cd-48ecf00fbc0e" />

<img width="759" height="641" alt="grafik" src="https://github.com/user-attachments/assets/3fb6f977-ee85-4521-abe6-c07f050ae872" />


### If we try to calculate the solution in R, we get a different result:
> d <- 3.4
> sd <- 3.7
> mu <- 4.9
> n <- 38
> 
> (d - mu) / (sd / sqrt(n))
[1] -2.499087

**Expected: -2.499087 
Actual: ~ 1.5**


The reason is that the .R topic file is loaded for each task and thus generating new data each time. 

This means that the last task loaded (confidence interval for paired t-test topic) should have correct solutions. Indeed, this is the case:

<img width="1391" height="634" alt="grafik" src="https://github.com/user-attachments/assets/f5c09c3e-5ba0-401e-873b-c552a7155523" />

<img width="776" height="399" alt="grafik" src="https://github.com/user-attachments/assets/7f3c6b65-5e45-4b8a-b376-3f913fd3bb4c" />

> d <- 3.4
> sd <- 3.7
> mu <- 4.9
> n <- 38
> lo <- d - (qt(1 - 0.05 / 2, df = n - 1) * sd / sqrt(n))
> hi <- d + (qt(1 - 0.05 / 2, df = n - 1) * sd / sqrt(n))
> call("...", lo, hi)
...(2.18384026290302, 4.61615973709698)



# After
<img width="1425" height="663" alt="grafik" src="https://github.com/user-attachments/assets/456d269a-0f6b-43f1-a021-6a407632eb98" />

<img width="782" height="583" alt="grafik" src="https://github.com/user-attachments/assets/ec9552e7-9bb7-4722-a6db-bcd8242cd780" />

> d <- 4.3
> sd <- 3.2
> mu <- 4.6
> n <- 22
> 
> (d - mu) / (sd / sqrt(n))
[1] -0.4397265


### Now the solution for the tratio task is also correct.








