### PR TITLE
Bug inconsistent evaluation of R expressions

### DIFF
--- a/interval.pl
+++ b/interval.pl
@@ -31,6 +31,10 @@
 % Assert clauses of interval_/3 at the beginning of module rint
 :- initialization(assert_clauses(interval_wrapper)).
 
+% Evaluation of R expression through r_session 
+:- asserta((rint:eval(r(Expr), Res) :-
+    !,
+    r_session:r_topic(Expr, Res))).
 %
 % Confidence intervals
 %

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -3,8 +3,12 @@
 :- use_module(library(plunit)).
 :- use_module(library(debug)).
 :- use_module('../interval').
+:- use_module('../r_session').
 
 test_interval :-
+    b_setval(topic, test),
+    b_setval(variant, var0),
+    r_session:r_topic, 
     run_tests([fractions, number_digit, bugs, multiply, available, equality, ci, pm, denote, color, semicolon, curly, cbinom, pwbinom]).
 
 :- begin_tests(fractions).

--- a/ztrans.pl
+++ b/ztrans.pl
@@ -18,10 +18,12 @@ task(quantile).
 
 % Prettier symbols for mathematical rendering
 math_hook(x, 'X').
+math_hook(x_1, x).
 math_hook(perc, p).
 
 % R definitions
 macro(x).
+macro(x_1).
 macro(sigma).
 macro(z).
 macro(perc).
@@ -174,7 +176,7 @@ intermediate(quantile, xcalc).
 expert(quantile, stage(1), From, To, [step(expert, steps, [])]) :-
     From = item(_X, Mu, Sigma, Perc),
     To = { '<-'(z, qnorm_(Perc / 100)) ;
-           '<-'(x, xcalc(z, Sigma, Mu))
+           '<-'(x_1, xcalc(z, Sigma, Mu))
          }.
 
 feedback(steps, [], _Col, F)


### PR DESCRIPTION
# Before

## Topic oddsratio2
<img width="570" height="917" alt="grafik" src="https://github.com/user-attachments/assets/2c9ec8dd-9d7c-479e-855e-8c080c50c1fc" />


#### The solution is 3.22, but three buggy rules have the same numerical value:

<img width="536" height="326" alt="grafik" src="https://github.com/user-attachments/assets/8265f7ed-0e16-4a7c-b42a-5de85f92f5d1" />

<img width="548" height="299" alt="grafik" src="https://github.com/user-attachments/assets/22283d1f-5591-4fd2-ab58-3980437e431a" />

<img width="583" height="323" alt="grafik" src="https://github.com/user-attachments/assets/b9e16d00-62d1-40cd-90e0-0af3f78eb4ea" />

That can't be the case. 

The problem is that the assignment operator '<-' is defined in rint and is evaluated through rolog. Therefore, the variable is saved in the base environment:

```
   Call: (26) rint:interval_(<-(atomic(odds_A), ...(3.5454545454545454, 3.7619047619047623)), _39412, [digits(2), topic(oddsratio2)]) ? creep
   Call: (27) rint:eval(r(<-(odds_A, call("...", 3.5454545454545454, 3.7619047619047623))), _40264) ? creep
   Call: (28) r:r(<-(odds_A, call("...", 3.5454545454545454, 3.7619047619047623)), _40264) ? creep
   Call: (29) rs_rolog:rx_eval(<-(odds_A, call("...", 3.5454545454545454, 3.7619047619047623)), _40264) ? 
```

But when the same variable is needed for a subsequent calculation, it is looked up through r_session and the variable already defined in oddsratio2.R is used. Indeed, we get a number, not the interval from the previous calculation:

```
   Call: (32) rint:interval_(atomic(odds_A), _49022, [digits(2), topic(oddsratio2)]) ? creep
   Call: (33) rint:eval(hook(r_session:r_topic, odds_A), _50690) ? creep
   Call: (34) r_session:r_topic(odds_A, _50690) ? creep
   Call: (35) b_getval(topic, _52336) ? creep
   Exit: (35) b_getval(topic, oddsratio2) ? creep
   Call: (35) b_getval(variant, _53958) ? creep
   Exit: (35) b_getval(variant, var0) ? creep
   Call: (35) r:r(with(oddsratio2, with(var0, odds_A)), _50690) ? skip
   Exit: (35) r:r(with(oddsratio2, with(var0, odds_A)), 3.5676147843109174) ? 
```

This causes the problem with buggy rules having the same result: the same predefined values are used for odds_A and odds_B regardless of the mistakes in formulas.


# After

<img width="595" height="905" alt="grafik" src="https://github.com/user-attachments/assets/f04127fe-9356-4b89-8541-1135edf59c4c" />

<img width="523" height="285" alt="grafik" src="https://github.com/user-attachments/assets/4b3967c7-4de5-48ae-9d3f-dc6c47e2536d" />

<img width="525" height="288" alt="grafik" src="https://github.com/user-attachments/assets/adc33def-5de5-42c2-b432-dcc1bcb34c99" />

<img width="534" height="304" alt="grafik" src="https://github.com/user-attachments/assets/15c15711-5847-4e5b-929e-770670abd302" />


